### PR TITLE
Add brew recipe creator, step timer, and session logging

### DIFF
--- a/backend/GrindAtlas.API/Controllers/Controllers.cs
+++ b/backend/GrindAtlas.API/Controllers/Controllers.cs
@@ -99,6 +99,7 @@ public class GrindLogsController(AppDbContext ctx, GrindEstimatorService estimat
         var q = ctx.GrindLogs
             .Include(l => l.Coffee)
             .Include(l => l.Grinder)
+            .Include(l => l.Recipe)
             .AsQueryable();
         if (coffeeId.HasValue)  q = q.Where(l => l.CoffeeId == coffeeId.Value);
         if (grinderId.HasValue) q = q.Where(l => l.GrinderId == grinderId.Value);
@@ -108,6 +109,7 @@ public class GrindLogsController(AppDbContext ctx, GrindEstimatorService estimat
     [HttpPost]
     public IActionResult Create(AddGrindLogRequest req)
     {
+        var notes = string.IsNullOrWhiteSpace(req.Notes) ? null : req.Notes.Trim();
         var ngi = estimator.NativeToNgi(req.NativeSetting, req.GrinderId);
         var log = new GrindLog
         {
@@ -120,13 +122,122 @@ public class GrindLogsController(AppDbContext ctx, GrindEstimatorService estimat
             YieldG           = req.YieldG,
             ExtractionTimeS  = req.ExtractionTimeS,
             Rating           = req.Rating,
-            Notes            = req.Notes,
+            Notes            = notes,
+            RecipeId         = req.RecipeId,
             BrewDate         = DateOnly.FromDateTime(DateTime.UtcNow),
             CreatedAt        = DateTime.UtcNow,
         };
         ctx.GrindLogs.Add(log);
         ctx.SaveChanges();
         return Ok(log);
+    }
+}
+
+// ── Recipes ───────────────────────────────────────────────────────────────────
+[ApiController, Route("api/[controller]")]
+public class RecipesController(AppDbContext ctx) : ControllerBase
+{
+    [HttpGet]
+    public IActionResult GetAll() =>
+        Ok(ctx.BrewRecipes
+            .Include(r => r.Coffee)
+            .Include(r => r.Grinder)
+            .Include(r => r.Steps.OrderBy(s => s.StepOrder))
+            .OrderByDescending(r => r.CreatedAt)
+            .ToList());
+
+    [HttpGet("{id}")]
+    public IActionResult Get(int id)
+    {
+        var recipe = ctx.BrewRecipes
+            .Include(r => r.Coffee)
+            .Include(r => r.Grinder)
+            .Include(r => r.Steps.OrderBy(s => s.StepOrder))
+            .FirstOrDefault(r => r.Id == id);
+        return recipe is null ? NotFound() : Ok(recipe);
+    }
+
+    [HttpPost]
+    public IActionResult Create(CreateBrewRecipeRequest req)
+    {
+        if (string.IsNullOrWhiteSpace(req.Name))
+            return BadRequest("Recipe name is required.");
+        if (req.Steps == null || req.Steps.Count == 0)
+            return BadRequest("A recipe must have at least one step.");
+
+        var recipe = new BrewRecipe
+        {
+            Name           = req.Name.Trim(),
+            CoffeeId       = req.CoffeeId,
+            GrinderId      = req.GrinderId,
+            BrewMethod     = req.BrewMethod,
+            NativeSetting  = req.NativeSetting,
+            DoseG          = req.DoseG,
+            WaterG         = req.WaterG,
+            WaterTempC     = req.WaterTempC,
+            TechniqueNotes = req.TechniqueNotes?.Trim(),
+            CreatedAt      = DateTime.UtcNow,
+            Steps          = req.Steps.Select(s => new BrewRecipeStep
+            {
+                StepOrder   = s.StepOrder,
+                Instruction = s.Instruction,
+                DurationS   = s.DurationS,
+                PourWaterG  = s.PourWaterG,
+            }).ToList(),
+        };
+        ctx.BrewRecipes.Add(recipe);
+        ctx.SaveChanges();
+        return CreatedAtAction(nameof(Get), new { id = recipe.Id }, recipe);
+    }
+
+    [HttpPut("{id}")]
+    public IActionResult Update(int id, CreateBrewRecipeRequest req)
+    {
+        if (string.IsNullOrWhiteSpace(req.Name))
+            return BadRequest("Recipe name is required.");
+        if (req.Steps == null || req.Steps.Count == 0)
+            return BadRequest("A recipe must have at least one step.");
+
+        var recipe = ctx.BrewRecipes
+            .Include(r => r.Steps)
+            .FirstOrDefault(r => r.Id == id);
+        if (recipe is null) return NotFound();
+
+        recipe.Name           = req.Name.Trim();
+        recipe.CoffeeId       = req.CoffeeId;
+        recipe.GrinderId      = req.GrinderId;
+        recipe.BrewMethod     = req.BrewMethod;
+        recipe.NativeSetting  = req.NativeSetting;
+        recipe.DoseG          = req.DoseG;
+        recipe.WaterG         = req.WaterG;
+        recipe.WaterTempC     = req.WaterTempC;
+        recipe.TechniqueNotes = req.TechniqueNotes?.Trim();
+
+        ctx.BrewRecipeSteps.RemoveRange(recipe.Steps);
+        recipe.Steps = req.Steps.Select(s => new BrewRecipeStep
+        {
+            RecipeId    = id,
+            StepOrder   = s.StepOrder,
+            Instruction = s.Instruction,
+            DurationS   = s.DurationS,
+            PourWaterG  = s.PourWaterG,
+        }).ToList();
+
+        ctx.SaveChanges();
+        return Ok(recipe);
+    }
+
+    [HttpDelete("{id}")]
+    public IActionResult Delete(int id)
+    {
+        var recipe = ctx.BrewRecipes
+            .Include(r => r.Steps)
+            .FirstOrDefault(r => r.Id == id);
+        if (recipe is null) return NotFound();
+        ctx.BrewRecipeSteps.RemoveRange(recipe.Steps);
+        ctx.BrewRecipes.Remove(recipe);
+        ctx.SaveChanges();
+        return NoContent();
     }
 }
 

--- a/backend/GrindAtlas.API/DTOs/Dtos.cs
+++ b/backend/GrindAtlas.API/DTOs/Dtos.cs
@@ -39,7 +39,23 @@ public record AddGrindLogRequest(
     decimal? YieldG,
     int? ExtractionTimeS,
     int? Rating,
-    string? Notes
+    string? Notes,
+    int? RecipeId
 );
 
 public record ConfirmEstimateRequest(decimal ConfirmedSetting);
+
+public record BrewRecipeStepRequest(int StepOrder, string Instruction, int DurationS, decimal? PourWaterG);
+
+public record CreateBrewRecipeRequest(
+    string Name,
+    int CoffeeId,
+    int GrinderId,
+    BrewMethod BrewMethod,
+    decimal? NativeSetting,
+    decimal? DoseG,
+    decimal? WaterG,
+    decimal? WaterTempC,
+    string? TechniqueNotes,
+    List<BrewRecipeStepRequest> Steps
+);

--- a/backend/GrindAtlas.API/Data/AppDbContext.cs
+++ b/backend/GrindAtlas.API/Data/AppDbContext.cs
@@ -10,6 +10,7 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
     public DbSet<GrinderCalibration> GrinderCalibrations => Set<GrinderCalibration>();
     public DbSet<GrindLog> GrindLogs => Set<GrindLog>();
     public DbSet<BrewRecipe> BrewRecipes => Set<BrewRecipe>();
+    public DbSet<BrewRecipeStep> BrewRecipeSteps => Set<BrewRecipeStep>();
     public DbSet<GrindEstimate> GrindEstimates => Set<GrindEstimate>();
 
     protected override void OnModelCreating(ModelBuilder mb)

--- a/backend/GrindAtlas.API/Models/GrindLog.cs
+++ b/backend/GrindAtlas.API/Models/GrindLog.cs
@@ -16,14 +16,17 @@ public class GrindLog
     public string? Notes { get; set; }
     public DateOnly? BrewDate { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public int? RecipeId { get; set; }
 
     public Coffee Coffee { get; set; } = null!;
     public Grinder Grinder { get; set; } = null!;
+    public BrewRecipe? Recipe { get; set; }
 }
 
 public class BrewRecipe
 {
     public int Id { get; set; }
+    public string Name { get; set; } = "";
     public int CoffeeId { get; set; }
     public int GrinderId { get; set; }
     public BrewMethod BrewMethod { get; set; }
@@ -42,4 +45,17 @@ public class BrewRecipe
 
     public Coffee Coffee { get; set; } = null!;
     public Grinder Grinder { get; set; } = null!;
+    public ICollection<BrewRecipeStep> Steps { get; set; } = new List<BrewRecipeStep>();
+}
+
+public class BrewRecipeStep
+{
+    public int Id { get; set; }
+    public int RecipeId { get; set; }
+    public int StepOrder { get; set; }
+    public string Instruction { get; set; } = "";
+    public int DurationS { get; set; }
+    public decimal? PourWaterG { get; set; }
+
+    public BrewRecipe Recipe { get; set; } = null!;
 }

--- a/backend/GrindAtlas.API/Program.cs
+++ b/backend/GrindAtlas.API/Program.cs
@@ -9,8 +9,11 @@ builder.Services.AddDbContext<AppDbContext>(opt =>
 
 builder.Services.AddScoped<GrindEstimatorService>();
 builder.Services.AddControllers()
-    .AddJsonOptions(o => o.JsonSerializerOptions.Converters.Add(
-        new System.Text.Json.Serialization.JsonStringEnumConverter()));
+    .AddJsonOptions(o =>
+    {
+        o.JsonSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
+        o.JsonSerializerOptions.ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.IgnoreCycles;
+    });
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/frontend/grind-atlas-ui/src/app/app.component.ts
+++ b/frontend/grind-atlas-ui/src/app/app.component.ts
@@ -18,6 +18,7 @@ import { RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
           <a class="sidebar-item" routerLink="/coffees"  routerLinkActive="active">Coffees</a>
           <a class="sidebar-item" routerLink="/grinders" routerLinkActive="active">Grinders</a>
           <a class="sidebar-item" routerLink="/logs"     routerLinkActive="active">Logs</a>
+          <a class="sidebar-item" routerLink="/recipes"  routerLinkActive="active">Recipes</a>
         </nav>
         <main class="main">
           <router-outlet />

--- a/frontend/grind-atlas-ui/src/app/app.routes.ts
+++ b/frontend/grind-atlas-ui/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { brewGuard } from './components/recipes/recipe-brew.component';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
@@ -36,6 +37,27 @@ export const routes: Routes = [
     path: 'logs',
     loadComponent: () =>
       import('./components/grind-logs/grind-logs.component').then(m => m.GrindLogsComponent),
+  },
+  {
+    path: 'recipes',
+    loadComponent: () =>
+      import('./components/recipes/recipes.component').then(m => m.RecipesComponent),
+  },
+  {
+    path: 'recipes/new',
+    loadComponent: () =>
+      import('./components/recipes/recipe-creator.component').then(m => m.RecipeCreatorComponent),
+  },
+  {
+    path: 'recipes/:id/edit',
+    loadComponent: () =>
+      import('./components/recipes/recipe-creator.component').then(m => m.RecipeCreatorComponent),
+  },
+  {
+    path: 'recipes/:id/brew',
+    loadComponent: () =>
+      import('./components/recipes/recipe-brew.component').then(m => m.RecipeBrewComponent),
+    canDeactivate: [brewGuard],
   },
   { path: '**', redirectTo: 'home' },
 ];

--- a/frontend/grind-atlas-ui/src/app/components/grind-logs/grind-logs.component.ts
+++ b/frontend/grind-atlas-ui/src/app/components/grind-logs/grind-logs.component.ts
@@ -98,12 +98,13 @@ import { Coffee, Grinder, GrindLog, BrewMethod, BREW_METHOD_LABELS, AddGrindLogR
     </div>
 
     <!-- Logs table -->
-    <div class="section-label">{{ logs.length }} logs</div>
+    <div class="section-label">{{ logs.length }} log{{ logs.length !== 1 ? 's' : '' }} — click a row to see notes</div>
     <div class="panel">
       <div style="overflow-x: auto;">
         <table class="table" style="min-width: 800px;">
           <thead>
             <tr>
+              <th></th>
               <th>Coffee</th>
               <th>Grinder</th>
               <th>Method</th>
@@ -111,22 +112,62 @@ import { Coffee, Grinder, GrindLog, BrewMethod, BREW_METHOD_LABELS, AddGrindLogR
               <th>NGI</th>
               <th>Dose</th>
               <th>Rating</th>
-              <th>Notes</th>
+              <th>Source</th>
             </tr>
           </thead>
           <tbody>
-            <tr *ngFor="let l of logs">
-              <td><strong>{{ l.coffee?.name ?? 'Coffee #' + l.coffeeId }}</strong></td>
-              <td>{{ l.grinder?.brand ?? '' }} {{ l.grinder?.model ?? '#' + l.grinderId }}</td>
-              <td>{{ formatMethod(l.brewMethod) }}</td>
-              <td><strong>{{ formatSetting(l) }}</strong></td>
-              <td><span class="status-pill s-hold">{{ l.ngiNormalized }}</span></td>
-              <td>{{ l.doseG ? l.doseG + 'g' : '—' }}</td>
-              <td>{{ l.rating ?? '—' }}</td>
-              <td style="max-width:180px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:#666;">{{ l.notes || '—' }}</td>
-            </tr>
+            <ng-container *ngFor="let l of logs">
+              <tr (click)="toggleExpand(l.id)" style="cursor:pointer;">
+                <td style="width:24px; padding:9px 8px;">
+                  <span style="font-size:10px; color:#999;">{{ expandedLogId === l.id ? '▼' : '▶' }}</span>
+                </td>
+                <td><strong>{{ l.coffee?.name ?? 'Coffee #' + l.coffeeId }}</strong></td>
+                <td>{{ l.grinder?.brand ?? '' }} {{ l.grinder?.model ?? '#' + l.grinderId }}</td>
+                <td>{{ formatMethod(l.brewMethod) }}</td>
+                <td><strong>{{ formatSetting(l) }}</strong></td>
+                <td><span class="status-pill s-hold">{{ l.ngiNormalized }}</span></td>
+                <td>{{ l.doseG ? l.doseG + 'g' : '—' }}</td>
+                <td>{{ l.rating ?? '—' }}</td>
+                <td>
+                  <span *ngIf="l.recipeId" class="status-pill s-active" style="font-size:9px;">Recipe</span>
+                  <span *ngIf="!l.recipeId" class="status-pill s-done" style="font-size:9px;">Quick Log</span>
+                </td>
+              </tr>
+              <!-- Expanded notes panel -->
+              <tr *ngIf="expandedLogId === l.id">
+                <td colspan="9" style="background:var(--paper); padding:0;">
+                  <div style="padding:14px 18px; border-left:4px solid var(--ink); font-size:13px;">
+                    <div style="display:flex; gap:32px; flex-wrap:wrap; margin-bottom:10px;">
+                      <div>
+                        <span class="form-label">Brew Date</span>
+                        <div>{{ l.brewDate ? formatDate(l.brewDate) : formatDate(l.createdAt) }}</div>
+                      </div>
+                      <div>
+                        <span class="form-label">Source</span>
+                        <div *ngIf="l.recipe"><strong>Recipe:</strong> {{ l.recipe.name }}</div>
+                        <div *ngIf="!l.recipe">Quick Log</div>
+                      </div>
+                      <div *ngIf="l.yieldG">
+                        <span class="form-label">Yield</span>
+                        <div>{{ l.yieldG }}g</div>
+                      </div>
+                      <div *ngIf="l.extractionTimeS">
+                        <span class="form-label">Extraction Time</span>
+                        <div>{{ l.extractionTimeS }}s</div>
+                      </div>
+                    </div>
+                    <div>
+                      <span class="form-label">Notes</span>
+                      <div style="margin-top:4px; color:{{ l.notes ? 'var(--ink)' : '#999' }};">
+                        {{ l.notes || 'No notes recorded.' }}
+                      </div>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </ng-container>
             <tr *ngIf="logs.length === 0">
-              <td colspan="8" style="text-align:center; color:#999; padding:20px;">No logs yet.</td>
+              <td colspan="9" style="text-align:center; color:#999; padding:20px;">No logs yet.</td>
             </tr>
           </tbody>
         </table>
@@ -144,6 +185,7 @@ export class GrindLogsComponent implements OnInit {
   logs: GrindLog[]    = [];
 
   showForm = false;
+  expandedLogId: number | null = null;
   brewMethods = Object.entries(BREW_METHOD_LABELS).map(([value, label]) => ({ value: value as BrewMethod, label }));
   newLog: Partial<AddGrindLogRequest> = {};
 
@@ -190,6 +232,10 @@ export class GrindLogsComponent implements OnInit {
     this.logService.getAll().subscribe(l => this.logs = l);
   }
 
+  toggleExpand(id: number) {
+    this.expandedLogId = this.expandedLogId === id ? null : id;
+  }
+
   submitLog() {
     if (!this.canSubmit) return;
     this.logService.create(this.newLog as AddGrindLogRequest).subscribe(log => {
@@ -203,6 +249,10 @@ export class GrindLogsComponent implements OnInit {
 
   formatMethod(m: string): string {
     return BREW_METHOD_LABELS[m as BrewMethod] ?? m;
+  }
+
+  formatDate(d: string): string {
+    return new Date(d).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
   }
 
   formatBound(v: number): string {

--- a/frontend/grind-atlas-ui/src/app/components/home/home.component.ts
+++ b/frontend/grind-atlas-ui/src/app/components/home/home.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { forkJoin } from 'rxjs';
-import { CoffeeService, GrinderService, GrindLogService } from '../../services/services';
+import { CoffeeService, GrinderService, GrindLogService, RecipeService } from '../../services/services';
 
 @Component({
   selector: 'app-home',
@@ -26,8 +26,8 @@ import { CoffeeService, GrinderService, GrindLogService } from '../../services/s
         <div class="stat-num">{{ logCount ?? '—' }}</div>
       </div>
       <div class="stat-card">
-        <div class="stat-label">Estimator</div>
-        <div class="stat-num" style="font-size:14px; padding-top:6px;">Ready</div>
+        <div class="stat-label">Recipes</div>
+        <div class="stat-num">{{ recipeCount ?? '—' }}</div>
       </div>
     </div>
 
@@ -82,6 +82,19 @@ import { CoffeeService, GrinderService, GrindLogService } from '../../services/s
           </div>
         </div>
       </div>
+
+      <div class="panel">
+        <div class="panel-head">
+          <span class="panel-title">Brew Recipes</span>
+        </div>
+        <div class="panel-body">
+          <p style="font-size:12px; margin: 0 0 14px; color:#555;">Build step-by-step brew recipes with a guided timer and session logging.</p>
+          <div style="display:flex; gap:10px;">
+            <a routerLink="/recipes" class="btn btn-inv btn-sm">View →</a>
+            <a routerLink="/recipes/new" class="btn btn-sm">New Recipe</a>
+          </div>
+        </div>
+      </div>
     </div>
   `,
 })
@@ -89,20 +102,24 @@ export class HomeComponent implements OnInit {
   private coffeeService  = inject(CoffeeService);
   private grinderService = inject(GrinderService);
   private logService     = inject(GrindLogService);
+  private recipeService  = inject(RecipeService);
 
   coffeeCount?: number;
   grinderCount?: number;
   logCount?: number;
+  recipeCount?: number;
 
   ngOnInit() {
     forkJoin({
       coffees:  this.coffeeService.getAll(),
       grinders: this.grinderService.getAll(),
       logs:     this.logService.getAll(),
-    }).subscribe(({ coffees, grinders, logs }) => {
+      recipes:  this.recipeService.getAll(),
+    }).subscribe(({ coffees, grinders, logs, recipes }) => {
       this.coffeeCount  = coffees.length;
       this.grinderCount = grinders.length;
       this.logCount     = logs.length;
+      this.recipeCount  = recipes.length;
     });
   }
 }

--- a/frontend/grind-atlas-ui/src/app/components/recipes/recipe-brew.component.ts
+++ b/frontend/grind-atlas-ui/src/app/components/recipes/recipe-brew.component.ts
@@ -1,0 +1,369 @@
+import { Component, OnInit, OnDestroy, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink, CanDeactivateFn } from '@angular/router';
+import { RecipeService, GrindLogService, GrinderService } from '../../services/services';
+import {
+  BrewRecipe, BrewRecipeStep, Grinder, BREW_METHOD_LABELS, BrewMethod,
+  AddGrindLogRequest
+} from '../../models/models';
+
+export const brewGuard: CanDeactivateFn<RecipeBrewComponent> = (component) => {
+  if (component.isRunning) {
+    return confirm('A brew is in progress. Are you sure you want to leave?');
+  }
+  return true;
+};
+
+@Component({
+  selector: 'app-recipe-brew',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  template: `
+    <div *ngIf="!recipe" style="text-align:center; padding:60px; color:#999;">Loading recipe…</div>
+
+    <ng-container *ngIf="recipe">
+      <!-- Header bar -->
+      <div style="display:flex; align-items:baseline; justify-content:space-between; margin-bottom:24px;">
+        <h1 class="page-title" style="margin-bottom:0;">{{ recipe.name }}</h1>
+        <a routerLink="/recipes" class="btn">← Recipes</a>
+      </div>
+
+      <!-- Recipe params reference strip -->
+      <div class="panel" style="margin-bottom:20px;">
+        <div class="panel-body" style="padding:12px 18px;">
+          <div style="display:flex; flex-wrap:wrap; gap:24px; font-size:12px;">
+            <div>
+              <span class="form-label" style="display:block;">Coffee</span>
+              <strong>{{ recipe.coffee?.name ?? 'Coffee #' + recipe.coffeeId }}</strong>
+            </div>
+            <div>
+              <span class="form-label" style="display:block;">Grinder</span>
+              <strong>{{ recipe.grinder?.brand }} {{ recipe.grinder?.model }}</strong>
+            </div>
+            <div>
+              <span class="form-label" style="display:block;">Method</span>
+              <strong>{{ formatMethod(recipe.brewMethod) }}</strong>
+            </div>
+            <div *ngIf="recipe.nativeSetting != null">
+              <span class="form-label" style="display:block;">Grind Setting</span>
+              <strong>{{ formatSetting(recipe.nativeSetting) }}</strong>
+            </div>
+            <div *ngIf="recipe.waterTempC != null">
+              <span class="form-label" style="display:block;">Water Temp</span>
+              <strong>{{ recipe.waterTempC }}°C</strong>
+            </div>
+            <div *ngIf="recipe.doseG != null">
+              <span class="form-label" style="display:block;">Dose</span>
+              <strong>{{ recipe.doseG }}g</strong>
+            </div>
+            <div *ngIf="recipe.waterG != null">
+              <span class="form-label" style="display:block;">Water</span>
+              <strong>{{ recipe.waterG }}g</strong>
+            </div>
+          </div>
+          <div *ngIf="recipe.techniqueNotes" style="margin-top:10px; font-size:12px; color:#555; border-top:1px solid var(--mid); padding-top:10px;">
+            {{ recipe.techniqueNotes }}
+          </div>
+        </div>
+      </div>
+
+      <!-- Timer display -->
+      <div class="panel" style="margin-bottom:20px;" *ngIf="!isComplete">
+        <div class="panel-body" style="padding:20px 18px;">
+          <div style="display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:16px;">
+            <div>
+              <div class="form-label">Elapsed</div>
+              <div style="font-size:48px; font-weight:700; letter-spacing:-0.04em; line-height:1; font-variant-numeric:tabular-nums;">
+                {{ formatTime(elapsedTotal) }}
+              </div>
+            </div>
+            <div style="display:flex; gap:12px; align-items:center;">
+              <button class="btn btn-inv" (click)="start()" *ngIf="!isRunning" [disabled]="isComplete">
+                {{ isPaused ? 'Resume' : 'Start' }}
+              </button>
+              <button class="btn" (click)="pause()" *ngIf="isRunning">Pause</button>
+              <button class="btn" (click)="reset()" *ngIf="isStarted">Reset</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Steps list -->
+      <div class="panel" style="margin-bottom:20px;" *ngIf="!isComplete">
+        <div class="panel-head"><span class="panel-title">Steps</span></div>
+        <div class="panel-body" style="padding:0;">
+          <div *ngFor="let step of recipe.steps; let i = index"
+            [style.border-bottom]="i < recipe.steps.length - 1 ? '1px solid var(--mid)' : 'none'"
+            [style.background]="isActiveStep(i) ? 'var(--paper)' : isCompletedStep(i) ? '#f9f9f9' : '#fff'"
+            style="padding:16px 18px; transition:background 0.2s;">
+
+            <div style="display:flex; align-items:flex-start; gap:16px;">
+              <!-- Step number / check -->
+              <div style="
+                min-width:32px; height:32px; border: var(--b-mid);
+                display:flex; align-items:center; justify-content:center;
+                font-weight:700; font-size:12px; flex-shrink:0;
+                background:{{ isCompletedStep(i) ? 'var(--ink)' : isActiveStep(i) ? 'var(--ink)' : 'transparent' }};
+                color:{{ isCompletedStep(i) || isActiveStep(i) ? 'var(--paper)' : 'var(--ink)' }};">
+                {{ isCompletedStep(i) ? '✓' : i + 1 }}
+              </div>
+
+              <!-- Content -->
+              <div style="flex:1;">
+                <div style="display:flex; align-items:baseline; justify-content:space-between; gap:16px; flex-wrap:wrap;">
+                  <div [style.color]="isCompletedStep(i) ? '#999' : 'var(--ink)'"
+                    [style.font-weight]="isActiveStep(i) ? '700' : '400'"
+                    style="font-size:14px;">
+                    {{ step.instruction }}
+                  </div>
+                  <div style="display:flex; gap:12px; align-items:baseline; flex-shrink:0;">
+                    <span *ngIf="step.pourWaterG" style="font-size:12px; color:#666;">
+                      {{ step.pourWaterG }}g
+                    </span>
+                    <span style="font-size:13px; font-variant-numeric:tabular-nums;"
+                      [style.color]="isCompletedStep(i) ? '#999' : 'var(--ink)'"
+                      [style.font-weight]="isActiveStep(i) ? '700' : '400'">
+                      {{ formatTime(step.durationS) }}
+                    </span>
+                  </div>
+                </div>
+
+                <!-- Active step progress -->
+                <div *ngIf="isActiveStep(i)" style="margin-top:10px;">
+                  <div style="display:flex; justify-content:space-between; font-size:11px; color:#666; margin-bottom:5px;">
+                    <span>Step {{ i + 1 }} of {{ recipe.steps.length }}</span>
+                    <span style="font-weight:700; font-variant-numeric:tabular-nums;">
+                      {{ formatTime(stepRemaining) }} remaining
+                    </span>
+                  </div>
+                  <div class="bar-track">
+                    <div class="bar-fill" [style.width.%]="stepProgress"
+                      style="transition: width 0.9s linear;"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Brew complete + review form -->
+      <div *ngIf="isComplete" class="panel" style="margin-bottom:20px;">
+        <div class="panel-head">
+          <span class="panel-title">Brew Complete — {{ formatTime(elapsedTotal) }}</span>
+        </div>
+        <div class="panel-body">
+          <p style="margin:0 0 20px; font-size:13px; color:#555;">
+            Log your results. At least one field is required to save.
+          </p>
+          <div class="form-grid-3" style="margin-bottom:14px;">
+            <div class="form-group" style="margin-bottom:0;">
+              <label class="form-label">Dose (g)</label>
+              <input type="number" [(ngModel)]="review.doseG" step="0.1" placeholder="e.g. 15">
+            </div>
+            <div class="form-group" style="margin-bottom:0;">
+              <label class="form-label">Yield (g)</label>
+              <input type="number" [(ngModel)]="review.yieldG" step="0.1" placeholder="e.g. 250">
+            </div>
+            <div class="form-group" style="margin-bottom:0;">
+              <label class="form-label">Extraction Time (s)</label>
+              <input type="number" [(ngModel)]="review.extractionTimeS" placeholder="e.g. 210">
+            </div>
+            <div class="form-group" style="margin-bottom:0;">
+              <label class="form-label">Rating (1–5)</label>
+              <select [(ngModel)]="review.rating">
+                <option [ngValue]="undefined">—</option>
+                <option [ngValue]="1">1</option>
+                <option [ngValue]="2">2</option>
+                <option [ngValue]="3">3</option>
+                <option [ngValue]="4">4</option>
+                <option [ngValue]="5">5</option>
+              </select>
+            </div>
+            <div class="form-group" style="margin-bottom:0; grid-column:span 2;">
+              <label class="form-label">Notes</label>
+              <input type="text" [(ngModel)]="review.notes" placeholder="Observations from this brew…">
+            </div>
+          </div>
+
+          <div style="display:flex; gap:12px; align-items:center;">
+            <button class="btn btn-inv" (click)="saveReview()" [disabled]="!canSaveReview || saving">
+              {{ saving ? 'Saving…' : 'Save Session' }}
+            </button>
+            <a routerLink="/recipes" class="btn btn-sm">Skip</a>
+          </div>
+          <div *ngIf="!canSaveReview" style="font-size:11px; color:#999; margin-top:8px;">
+            Fill in at least one field to save.
+          </div>
+        </div>
+      </div>
+    </ng-container>
+  `,
+})
+export class RecipeBrewComponent implements OnInit, OnDestroy {
+  private recipeService  = inject(RecipeService);
+  private logService     = inject(GrindLogService);
+  private grinderService = inject(GrinderService);
+  private route          = inject(ActivatedRoute);
+  private router         = inject(Router);
+
+  recipe?: BrewRecipe;
+  grinder?: Grinder;
+
+  // Timer state
+  isStarted  = false;
+  isRunning  = false;
+  isPaused   = false;
+  isComplete = false;
+  elapsedTotal     = 0;
+  currentStepIndex = 0;
+  stepElapsed      = 0;
+  private timerHandle?: ReturnType<typeof setInterval>;
+
+  // Review form
+  review: { doseG?: number; yieldG?: number; extractionTimeS?: number; rating?: number; notes?: string } = {};
+  saving = false;
+
+  get stepRemaining(): number {
+    const s = this.recipe?.steps[this.currentStepIndex];
+    return s ? Math.max(0, s.durationS - this.stepElapsed) : 0;
+  }
+
+  get stepProgress(): number {
+    const s = this.recipe?.steps[this.currentStepIndex];
+    if (!s || s.durationS === 0) return 100;
+    return Math.min(100, (this.stepElapsed / s.durationS) * 100);
+  }
+
+  get canSaveReview(): boolean {
+    return !!(this.review.doseG || this.review.yieldG || this.review.extractionTimeS ||
+              this.review.rating || (this.review.notes && this.review.notes.trim()));
+  }
+
+  ngOnInit() {
+    const id = +this.route.snapshot.paramMap.get('id')!;
+    this.recipeService.getById(id).subscribe(r => {
+      this.recipe = r;
+      if (r.grinderId) {
+        this.grinderService.getById(r.grinderId).subscribe(g => this.grinder = g);
+      }
+    });
+  }
+
+  ngOnDestroy() {
+    this.stopTimer();
+  }
+
+  isActiveStep(i: number): boolean {
+    return this.isStarted && !this.isComplete && i === this.currentStepIndex;
+  }
+
+  isCompletedStep(i: number): boolean {
+    return this.isStarted && i < this.currentStepIndex;
+  }
+
+  start() {
+    if (!this.recipe || this.isComplete) return;
+    this.isStarted = true;
+    this.isRunning = true;
+    this.isPaused  = false;
+    this.timerHandle = setInterval(() => this.tick(), 1000);
+  }
+
+  pause() {
+    this.isRunning = false;
+    this.isPaused  = true;
+    this.stopTimer();
+  }
+
+  reset() {
+    this.stopTimer();
+    this.isStarted       = false;
+    this.isRunning       = false;
+    this.isPaused        = false;
+    this.isComplete      = false;
+    this.elapsedTotal    = 0;
+    this.currentStepIndex = 0;
+    this.stepElapsed     = 0;
+  }
+
+  private tick() {
+    if (!this.recipe) return;
+    this.elapsedTotal++;
+    this.stepElapsed++;
+    const step = this.recipe.steps[this.currentStepIndex];
+    if (step && this.stepElapsed >= step.durationS) {
+      if (this.currentStepIndex < this.recipe.steps.length - 1) {
+        this.currentStepIndex++;
+        this.stepElapsed = 0;
+      } else {
+        this.stopTimer();
+        this.isRunning  = false;
+        this.isComplete = true;
+      }
+    }
+  }
+
+  private stopTimer() {
+    if (this.timerHandle) {
+      clearInterval(this.timerHandle);
+      this.timerHandle = undefined;
+    }
+  }
+
+  saveReview() {
+    if (!this.canSaveReview || !this.recipe || this.saving) return;
+    this.saving = true;
+    const req: AddGrindLogRequest = {
+      coffeeId:        this.recipe.coffeeId,
+      grinderId:       this.recipe.grinderId,
+      brewMethod:      this.recipe.brewMethod,
+      nativeSetting:   this.recipe.nativeSetting ?? 0,
+      doseG:           this.review.doseG,
+      yieldG:          this.review.yieldG,
+      extractionTimeS: this.review.extractionTimeS,
+      rating:          this.review.rating,
+      notes:           this.review.notes?.trim() || undefined,
+      recipeId:        this.recipe.id,
+    };
+    this.logService.create(req).subscribe({
+      next:  () => this.router.navigate(['/logs']),
+      error: () => { this.saving = false; },
+    });
+  }
+
+  formatTime(seconds: number): string {
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  }
+
+  formatMethod(m: string): string {
+    return BREW_METHOD_LABELS[m as BrewMethod] ?? m;
+  }
+
+  formatSetting(native: number): string {
+    const g = this.grinder ?? this.recipe?.grinder;
+    if (!g) return String(native);
+    if (g.scaleType === 'Alpha') return this.numToAlpha(Math.round(native));
+    if (g.scaleType === 'AlphaNumeric') return this.numToAlphaNum(native, g.scaleSubDivisions ?? 9, g.scaleFormat ?? 'A1');
+    return String(native);
+  }
+
+  numToAlpha(n: number): string {
+    n = Math.round(n);
+    if (n <= 0) return 'A';
+    let result = '';
+    while (n > 0) { n--; result = String.fromCharCode(65 + (n % 26)) + result; n = Math.floor(n / 26); }
+    return result;
+  }
+
+  numToAlphaNum(n: number, subDivs: number, format: string): string {
+    n = Math.round(n * 10) / 10;
+    const letterIdx = Math.floor((n - 1) / subDivs) + 1;
+    const sub = Math.round(((n - 1) % subDivs) + 1);
+    const letter = this.numToAlpha(letterIdx);
+    return (format ?? 'A1') === '1A' ? `${sub}${letter}` : `${letter}${sub}`;
+  }
+}

--- a/frontend/grind-atlas-ui/src/app/components/recipes/recipe-creator.component.ts
+++ b/frontend/grind-atlas-ui/src/app/components/recipes/recipe-creator.component.ts
@@ -1,0 +1,365 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { CoffeeService, GrinderService, RecipeService } from '../../services/services';
+import {
+  Coffee, Grinder, BrewMethod, BREW_METHOD_LABELS,
+  CreateBrewRecipeRequest, BrewRecipe
+} from '../../models/models';
+
+interface StepForm {
+  instruction: string;
+  durationDisplay: string; // "MM:SS" displayed in input
+  durationS: number;       // actual seconds
+  pourWaterG: number | undefined;
+}
+
+@Component({
+  selector: 'app-recipe-creator',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  template: `
+    <div style="display:flex; align-items:baseline; justify-content:space-between; margin-bottom:24px;">
+      <h1 class="page-title" style="margin-bottom:0;">{{ isEditMode ? 'Edit Recipe' : 'New Recipe' }}</h1>
+      <a routerLink="/recipes" class="btn">Cancel</a>
+    </div>
+
+    <!-- Recipe header fields -->
+    <div class="panel" style="margin-bottom:20px;">
+      <div class="panel-head"><span class="panel-title">Recipe Details</span></div>
+      <div class="panel-body">
+        <div class="form-group">
+          <label class="form-label">Recipe Name *</label>
+          <input type="text" [(ngModel)]="name" placeholder="e.g. Morning V60 Light Roast" maxlength="100">
+        </div>
+        <div class="form-grid-3" style="margin-bottom:14px;">
+          <div class="form-group" style="margin-bottom:0;">
+            <label class="form-label">Coffee *</label>
+            <select [(ngModel)]="coffeeId">
+              <option [ngValue]="undefined">Select coffee…</option>
+              <option *ngFor="let c of coffees" [ngValue]="c.id">{{ c.name }}</option>
+            </select>
+          </div>
+          <div class="form-group" style="margin-bottom:0;">
+            <label class="form-label">Grinder *</label>
+            <select [(ngModel)]="grinderId" (ngModelChange)="onGrinderChange()">
+              <option [ngValue]="undefined">Select grinder…</option>
+              <option *ngFor="let g of grinders" [ngValue]="g.id">{{ g.brand }} {{ g.model }}</option>
+            </select>
+          </div>
+          <div class="form-group" style="margin-bottom:0;">
+            <label class="form-label">Brew Method *</label>
+            <select [(ngModel)]="brewMethod">
+              <option [ngValue]="undefined">Select method…</option>
+              <option *ngFor="let m of brewMethods" [ngValue]="m.value">{{ m.label }}</option>
+            </select>
+          </div>
+        </div>
+
+        <!-- Grind setting -->
+        <div class="form-grid-3" style="margin-bottom:14px;">
+          <ng-container *ngIf="selectedGrinder; else numericFallback">
+            <div class="form-group" style="margin-bottom:0;">
+              <label class="form-label">Grind Setting</label>
+              <div class="slider-wrap">
+                <span class="slider-value">{{ sliderLabel }}</span>
+                <input type="range" [(ngModel)]="nativeSetting"
+                  [min]="sliderMin" [max]="sliderMax" [step]="sliderStep">
+                <div class="slider-bounds">
+                  <span>{{ formatBound(sliderMin) }}</span>
+                  <span>{{ formatBound(sliderMax) }}</span>
+                </div>
+              </div>
+            </div>
+          </ng-container>
+          <ng-template #numericFallback>
+            <div class="form-group" style="margin-bottom:0;">
+              <label class="form-label">Grind Setting</label>
+              <input type="number" [(ngModel)]="nativeSetting" step="0.5" placeholder="Select a grinder first">
+            </div>
+          </ng-template>
+
+          <div class="form-group" style="margin-bottom:0;">
+            <label class="form-label">Dose (g)</label>
+            <input type="number" [(ngModel)]="doseG" step="0.1" placeholder="e.g. 15">
+          </div>
+          <div class="form-group" style="margin-bottom:0;">
+            <label class="form-label">Water (g)</label>
+            <input type="number" [(ngModel)]="waterG" step="1" placeholder="e.g. 250">
+          </div>
+          <div class="form-group" style="margin-bottom:0;">
+            <label class="form-label">Water Temp (°C)</label>
+            <input type="number" [(ngModel)]="waterTempC" step="0.5" placeholder="e.g. 93">
+          </div>
+        </div>
+
+        <div class="form-group" style="margin-bottom:0;">
+          <label class="form-label">Technique Notes</label>
+          <textarea [(ngModel)]="techniqueNotes" rows="2" placeholder="Pouring technique, agitation, etc."></textarea>
+        </div>
+      </div>
+    </div>
+
+    <!-- Steps section -->
+    <div class="panel" style="margin-bottom:20px;">
+      <div class="panel-head">
+        <span class="panel-title">Steps</span>
+        <div style="display:flex; align-items:center; gap:16px;">
+          <span style="font-size:12px; color:#666;" *ngIf="steps.length > 0">
+            Total: {{ formatTotalTime() }}
+          </span>
+          <button class="btn btn-sm" (click)="addStep()">+ Add Step</button>
+        </div>
+      </div>
+      <div class="panel-body">
+        <div *ngIf="steps.length === 0" style="text-align:center; color:#999; padding:24px 0; font-size:13px;">
+          No steps yet — add at least one step to save this recipe.
+        </div>
+
+        <div *ngFor="let step of steps; let i = index"
+          style="border-bottom: 1px solid var(--mid); padding:14px 0;"
+          [style.border-bottom]="i === steps.length - 1 ? 'none' : '1px solid var(--mid)'">
+          <div style="display:flex; align-items:flex-start; gap:12px;">
+            <!-- Step number -->
+            <div style="
+              min-width:28px; height:28px; border: var(--b-thin);
+              display:flex; align-items:center; justify-content:center;
+              font-weight:700; font-size:12px; flex-shrink:0; margin-top:2px;">
+              {{ i + 1 }}
+            </div>
+
+            <!-- Fields -->
+            <div style="flex:1; display:grid; grid-template-columns:1fr auto auto; gap:12px; align-items:start;">
+              <div class="form-group" style="margin-bottom:0;">
+                <label class="form-label">Instruction</label>
+                <input type="text" [(ngModel)]="step.instruction"
+                  placeholder="e.g. Bloom — pour 50g water">
+              </div>
+              <div class="form-group" style="margin-bottom:0; min-width:100px;">
+                <label class="form-label">Duration (MM:SS)</label>
+                <input type="text" [ngModel]="step.durationDisplay"
+                  (ngModelChange)="step.durationDisplay = $event"
+                  (blur)="parseDuration(step)"
+                  placeholder="0:30"
+                  style="font-variant-numeric: tabular-nums;">
+              </div>
+              <div class="form-group" style="margin-bottom:0; min-width:90px;">
+                <label class="form-label">Pour (g)</label>
+                <input type="number" [(ngModel)]="step.pourWaterG" step="1" placeholder="—">
+              </div>
+            </div>
+
+            <!-- Reorder + remove -->
+            <div style="display:flex; flex-direction:column; gap:4px; flex-shrink:0; margin-top:18px;">
+              <button class="btn btn-sm" (click)="moveStep(i, -1)" [disabled]="i === 0"
+                style="padding:3px 8px; font-size:10px;">↑</button>
+              <button class="btn btn-sm" (click)="moveStep(i, 1)" [disabled]="i === steps.length - 1"
+                style="padding:3px 8px; font-size:10px;">↓</button>
+              <button class="btn btn-sm" (click)="removeStep(i)"
+                style="padding:3px 8px; font-size:10px;">✕</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Error -->
+    <div class="error-msg" *ngIf="error" style="margin-bottom:16px;">{{ error }}</div>
+
+    <!-- Save -->
+    <button class="btn btn-inv" (click)="save()" [disabled]="!canSave">
+      {{ isEditMode ? 'Save Changes' : 'Create Recipe' }}
+    </button>
+  `,
+})
+export class RecipeCreatorComponent implements OnInit {
+  private coffeeService  = inject(CoffeeService);
+  private grinderService = inject(GrinderService);
+  private recipeService  = inject(RecipeService);
+  private route          = inject(ActivatedRoute);
+  private router         = inject(Router);
+
+  coffees: Coffee[]   = [];
+  grinders: Grinder[] = [];
+  brewMethods = Object.entries(BREW_METHOD_LABELS).map(([value, label]) => ({ value: value as BrewMethod, label }));
+
+  // form fields
+  name        = '';
+  coffeeId?: number;
+  grinderId?: number;
+  brewMethod?: BrewMethod;
+  nativeSetting?: number;
+  doseG?: number;
+  waterG?: number;
+  waterTempC?: number;
+  techniqueNotes = '';
+  steps: StepForm[] = [];
+
+  isEditMode = false;
+  editId?: number;
+  error = '';
+
+  get canSave(): boolean {
+    return !!this.name.trim() && !!this.coffeeId && !!this.grinderId && !!this.brewMethod &&
+           this.steps.length > 0 && this.steps.every(s => !!s.instruction.trim() && s.durationS > 0);
+  }
+
+  get selectedGrinder(): Grinder | undefined {
+    return this.grinders.find(g => g.id === this.grinderId);
+  }
+
+  get sliderMin(): number { return this.selectedGrinder?.scaleMin ?? 0; }
+  get sliderMax(): number { return this.selectedGrinder?.scaleMax ?? 100; }
+
+  get sliderStep(): number {
+    const g = this.selectedGrinder;
+    if (!g) return 1;
+    if (g.scaleType === 'AlphaNumeric') return (g.scaleSubType ?? 'Stepped') === 'Stepless' ? 0.5 : 1;
+    return g.grindType === 'Stepless' ? 0.5 : 1;
+  }
+
+  get sliderLabel(): string {
+    const g = this.selectedGrinder;
+    const v = this.nativeSetting;
+    if (v == null || !g) return '—';
+    if (g.scaleType === 'Alpha') return this.numToAlpha(Math.round(v));
+    if (g.scaleType === 'AlphaNumeric') return this.numToAlphaNum(v, g.scaleSubDivisions ?? 9, g.scaleFormat ?? 'A1');
+    return String(v);
+  }
+
+  formatBound(v: number): string {
+    const g = this.selectedGrinder;
+    if (!g) return String(v);
+    if (g.scaleType === 'Alpha') return this.numToAlpha(Math.round(v));
+    if (g.scaleType === 'AlphaNumeric') return this.numToAlphaNum(v, g.scaleSubDivisions ?? 9, g.scaleFormat ?? 'A1');
+    return String(v);
+  }
+
+  onGrinderChange() {
+    const g = this.selectedGrinder;
+    this.nativeSetting = g ? g.scaleMin : undefined;
+  }
+
+  ngOnInit() {
+    this.coffeeService.getAll().subscribe(c => this.coffees = c);
+    this.grinderService.getAll().subscribe(g => this.grinders = g);
+
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      this.isEditMode = true;
+      this.editId = +id;
+      this.recipeService.getById(this.editId).subscribe(r => this.loadRecipe(r));
+    }
+  }
+
+  loadRecipe(r: BrewRecipe) {
+    this.name          = r.name;
+    this.coffeeId      = r.coffeeId;
+    this.grinderId     = r.grinderId;
+    this.brewMethod    = r.brewMethod;
+    this.nativeSetting = r.nativeSetting;
+    this.doseG         = r.doseG;
+    this.waterG        = r.waterG;
+    this.waterTempC    = r.waterTempC;
+    this.techniqueNotes = r.techniqueNotes ?? '';
+    this.steps = r.steps.map(s => ({
+      instruction:     s.instruction,
+      durationS:       s.durationS,
+      durationDisplay: this.formatDuration(s.durationS),
+      pourWaterG:      s.pourWaterG,
+    }));
+  }
+
+  addStep() {
+    this.steps.push({ instruction: '', durationS: 0, durationDisplay: '0:30', pourWaterG: undefined });
+    // Parse the default display value
+    this.parseDuration(this.steps[this.steps.length - 1]);
+  }
+
+  removeStep(i: number) {
+    this.steps.splice(i, 1);
+  }
+
+  moveStep(i: number, dir: -1 | 1) {
+    const j = i + dir;
+    if (j < 0 || j >= this.steps.length) return;
+    [this.steps[i], this.steps[j]] = [this.steps[j], this.steps[i]];
+  }
+
+  parseDuration(step: StepForm) {
+    const raw = step.durationDisplay.trim();
+    const parts = raw.split(':');
+    let seconds = 0;
+    if (parts.length === 2) {
+      seconds = (parseInt(parts[0], 10) || 0) * 60 + (parseInt(parts[1], 10) || 0);
+    } else {
+      seconds = parseInt(raw, 10) || 0;
+    }
+    step.durationS = Math.max(0, seconds);
+    step.durationDisplay = this.formatDuration(step.durationS);
+  }
+
+  formatDuration(s: number): string {
+    const m = Math.floor(s / 60);
+    const sec = s % 60;
+    return `${m}:${sec.toString().padStart(2, '0')}`;
+  }
+
+  formatTotalTime(): string {
+    const total = this.steps.reduce((sum, s) => sum + s.durationS, 0);
+    const m = Math.floor(total / 60);
+    const s = total % 60;
+    if (m > 0 && s > 0) return `${m}m ${s}s`;
+    if (m > 0) return `${m}m`;
+    return `${s}s`;
+  }
+
+  save() {
+    if (!this.canSave) return;
+    this.error = '';
+
+    const req: CreateBrewRecipeRequest = {
+      name:           this.name.trim(),
+      coffeeId:       this.coffeeId!,
+      grinderId:      this.grinderId!,
+      brewMethod:     this.brewMethod!,
+      nativeSetting:  this.nativeSetting,
+      doseG:          this.doseG,
+      waterG:         this.waterG,
+      waterTempC:     this.waterTempC,
+      techniqueNotes: this.techniqueNotes.trim() || undefined,
+      steps:          this.steps.map((s, i) => ({
+        stepOrder:   i + 1,
+        instruction: s.instruction.trim(),
+        durationS:   s.durationS,
+        pourWaterG:  s.pourWaterG,
+      })),
+    };
+
+    const op = this.isEditMode
+      ? this.recipeService.update(this.editId!, req)
+      : this.recipeService.create(req);
+
+    op.subscribe({
+      next:  () => this.router.navigate(['/recipes']),
+      error: (e) => { this.error = e?.error ?? 'Failed to save recipe.'; },
+    });
+  }
+
+  numToAlpha(n: number): string {
+    n = Math.round(n);
+    if (n <= 0) return 'A';
+    let result = '';
+    while (n > 0) { n--; result = String.fromCharCode(65 + (n % 26)) + result; n = Math.floor(n / 26); }
+    return result;
+  }
+
+  numToAlphaNum(n: number, subDivs: number, format: string): string {
+    n = Math.round(n * 10) / 10;
+    const letterIdx = Math.floor((n - 1) / subDivs) + 1;
+    const sub = Math.round(((n - 1) % subDivs) + 1);
+    const letter = this.numToAlpha(letterIdx);
+    return (format ?? 'A1') === '1A' ? `${sub}${letter}` : `${letter}${sub}`;
+  }
+}

--- a/frontend/grind-atlas-ui/src/app/components/recipes/recipes.component.ts
+++ b/frontend/grind-atlas-ui/src/app/components/recipes/recipes.component.ts
@@ -1,0 +1,116 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { RecipeService } from '../../services/services';
+import { BrewRecipe, BREW_METHOD_LABELS, BrewMethod } from '../../models/models';
+
+@Component({
+  selector: 'app-recipes',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  template: `
+    <div style="display:flex; align-items:baseline; justify-content:space-between; margin-bottom:24px;">
+      <h1 class="page-title" style="margin-bottom:0;">Brew Recipes</h1>
+      <a routerLink="/recipes/new" class="btn">New Recipe</a>
+    </div>
+
+    <div class="section-label">{{ recipes.length }} recipe{{ recipes.length !== 1 ? 's' : '' }}</div>
+
+    <div class="panel" *ngIf="recipes.length > 0">
+      <div style="overflow-x: auto;">
+        <table class="table" style="min-width: 700px;">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Coffee</th>
+              <th>Grinder</th>
+              <th>Method</th>
+              <th>Steps</th>
+              <th>Total Time</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let r of recipes">
+              <td><strong>{{ r.name }}</strong></td>
+              <td>{{ r.coffee?.name ?? 'Coffee #' + r.coffeeId }}</td>
+              <td>{{ r.grinder?.brand ?? '' }} {{ r.grinder?.model ?? '#' + r.grinderId }}</td>
+              <td>{{ formatMethod(r.brewMethod) }}</td>
+              <td>
+                <span class="status-pill s-hold">{{ r.steps.length }} step{{ r.steps.length !== 1 ? 's' : '' }}</span>
+              </td>
+              <td>{{ formatTotalTime(r) }}</td>
+              <td>
+                <div style="display:flex; gap:8px;">
+                  <a [routerLink]="['/recipes', r.id, 'brew']" class="btn btn-inv btn-sm">Brew →</a>
+                  <a [routerLink]="['/recipes', r.id, 'edit']" class="btn btn-sm">Edit</a>
+                  <button class="btn btn-sm" (click)="confirmDelete(r)">Delete</button>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="panel" *ngIf="recipes.length === 0">
+      <div class="panel-body" style="text-align:center; color:#999; padding:40px 20px;">
+        <div style="font-size:13px; margin-bottom:14px;">No recipes yet. Create your first brew recipe.</div>
+        <a routerLink="/recipes/new" class="btn btn-inv">New Recipe</a>
+      </div>
+    </div>
+
+    <!-- Delete confirmation overlay -->
+    <div *ngIf="pendingDelete" style="
+      position:fixed; inset:0; background:rgba(10,10,10,0.6);
+      display:flex; align-items:center; justify-content:center; z-index:100;">
+      <div class="panel" style="width:380px; background:#fff;">
+        <div class="panel-head"><span class="panel-title">Confirm Delete</span></div>
+        <div class="panel-body">
+          <p style="margin:0 0 20px; font-size:13px;">
+            Delete <strong>{{ pendingDelete.name }}</strong>? This cannot be undone.
+          </p>
+          <div style="display:flex; gap:10px;">
+            <button class="btn btn-inv btn-sm" (click)="deleteRecipe()">Delete</button>
+            <button class="btn btn-sm" (click)="pendingDelete = null">Cancel</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class RecipesComponent implements OnInit {
+  private recipeService = inject(RecipeService);
+
+  recipes: BrewRecipe[] = [];
+  pendingDelete: BrewRecipe | null = null;
+
+  ngOnInit() {
+    this.recipeService.getAll().subscribe(r => this.recipes = r);
+  }
+
+  formatMethod(m: string): string {
+    return BREW_METHOD_LABELS[m as BrewMethod] ?? m;
+  }
+
+  formatTotalTime(r: BrewRecipe): string {
+    const total = r.steps.reduce((sum, s) => sum + s.durationS, 0);
+    if (total === 0) return '—';
+    const m = Math.floor(total / 60);
+    const s = total % 60;
+    return m > 0 ? `${m}m ${s > 0 ? s + 's' : ''}`.trim() : `${s}s`;
+  }
+
+  confirmDelete(r: BrewRecipe) {
+    this.pendingDelete = r;
+  }
+
+  deleteRecipe() {
+    if (!this.pendingDelete) return;
+    const id = this.pendingDelete.id;
+    this.pendingDelete = null;
+    this.recipeService.delete(id).subscribe(() => {
+      this.recipes = this.recipes.filter(r => r.id !== id);
+    });
+  }
+}

--- a/frontend/grind-atlas-ui/src/app/models/models.ts
+++ b/frontend/grind-atlas-ui/src/app/models/models.ts
@@ -70,8 +70,10 @@ export interface GrindLog {
   notes?: string;
   brewDate?: string;
   createdAt: string;
+  recipeId?: number;
   coffee?: Coffee;
   grinder?: Grinder;
+  recipe?: BrewRecipe;
 }
 
 export type BrewMethod =
@@ -89,6 +91,53 @@ export const BREW_METHOD_LABELS: Record<BrewMethod, string> = {
   ColdBrew: 'Cold Brew',
   Siphon: 'Siphon',
 };
+
+// brew-recipe.model.ts
+export interface BrewRecipeStep {
+  id: number;
+  recipeId: number;
+  stepOrder: number;
+  instruction: string;
+  durationS: number;
+  pourWaterG?: number;
+}
+
+export interface BrewRecipe {
+  id: number;
+  name: string;
+  coffeeId: number;
+  grinderId: number;
+  brewMethod: BrewMethod;
+  nativeSetting?: number;
+  doseG?: number;
+  waterG?: number;
+  waterTempC?: number;
+  techniqueNotes?: string;
+  rating?: number;
+  isFavorite: boolean;
+  steps: BrewRecipeStep[];
+  createdAt: string;
+  coffee?: Coffee;
+  grinder?: Grinder;
+}
+
+export interface CreateBrewRecipeRequest {
+  name: string;
+  coffeeId: number;
+  grinderId: number;
+  brewMethod: BrewMethod;
+  nativeSetting?: number;
+  doseG?: number;
+  waterG?: number;
+  waterTempC?: number;
+  techniqueNotes?: string;
+  steps: {
+    stepOrder: number;
+    instruction: string;
+    durationS: number;
+    pourWaterG?: number;
+  }[];
+}
 
 // estimate.model.ts
 export interface EstimateRequest {
@@ -123,4 +172,5 @@ export interface AddGrindLogRequest {
   extractionTimeS?: number;
   rating?: number;
   notes?: string;
+  recipeId?: number;
 }

--- a/frontend/grind-atlas-ui/src/app/services/services.ts
+++ b/frontend/grind-atlas-ui/src/app/services/services.ts
@@ -3,7 +3,8 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import {
   Coffee, Grinder, GrindLog, EstimateRequest, EstimateResponse,
-  AddGrindLogRequest, BrewMethod, ProcessingMethod
+  AddGrindLogRequest, BrewMethod, ProcessingMethod,
+  BrewRecipe, CreateBrewRecipeRequest
 } from '../models/models';
 
 const BASE = 'http://localhost:5000/api';
@@ -74,6 +75,32 @@ export class GrindLogService {
 
   create(req: AddGrindLogRequest): Observable<GrindLog> {
     return this.http.post<GrindLog>(`${BASE}/grindlogs`, req);
+  }
+}
+
+// ── Recipe Service ────────────────────────────────────────────────────────────
+@Injectable({ providedIn: 'root' })
+export class RecipeService {
+  private http = inject(HttpClient);
+
+  getAll(): Observable<BrewRecipe[]> {
+    return this.http.get<BrewRecipe[]>(`${BASE}/recipes`);
+  }
+
+  getById(id: number): Observable<BrewRecipe> {
+    return this.http.get<BrewRecipe>(`${BASE}/recipes/${id}`);
+  }
+
+  create(req: CreateBrewRecipeRequest): Observable<BrewRecipe> {
+    return this.http.post<BrewRecipe>(`${BASE}/recipes`, req);
+  }
+
+  update(id: number, req: CreateBrewRecipeRequest): Observable<BrewRecipe> {
+    return this.http.put<BrewRecipe>(`${BASE}/recipes/${id}`, req);
+  }
+
+  delete(id: number): Observable<void> {
+    return this.http.delete<void>(`${BASE}/recipes/${id}`);
   }
 }
 


### PR DESCRIPTION
- Backend: BrewRecipeStep model, Steps collection + Name on BrewRecipe,
  RecipeId FK on GrindLog, RecipesController (CRUD with 0-step validation),
  notes whitespace trimmed/nulled on save, ReferenceHandler.IgnoreCycles
- Frontend: BrewRecipe/BrewRecipeStep/CreateBrewRecipeRequest models,
  RecipeService; RecipesComponent (list + delete confirm overlay);
  RecipeCreatorComponent (create + edit, MM:SS duration input, running
  total time, up/down reorder, disabled save when 0 steps or name empty);
  RecipeBrewComponent (recipe header strip, 48px elapsed timer, per-step
  countdown + draining progress bar, active step highlight, brewGuard
  canDeactivate, review form blocked when all fields empty);
  grind-logs clickable rows with expandable notes panel showing brew date,
  Recipe/Quick Log source label, yield, extraction time, full notes;
  home Recipes stat card + nav panel; sidebar Recipes link; new routes

https://claude.ai/code/session_01TcmWzbgX2FVq1aXhAsAhxF