### PR TITLE
feat: My Shelf, My Setup, Bag Tracking, Estimator Priority, Save Session improvements, Auth redirect

### DIFF
--- a/backend/GrindAtlas.API.Tests/CollectionControllerTests.cs
+++ b/backend/GrindAtlas.API.Tests/CollectionControllerTests.cs
@@ -1,0 +1,343 @@
+using GrindAtlas.API.Controllers;
+using GrindAtlas.API.Data;
+using GrindAtlas.API.DTOs;
+using GrindAtlas.API.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+
+namespace GrindAtlas.API.Tests;
+
+public class CollectionControllerTests
+{
+    private static AppDbContext CreateDb(string name)
+    {
+        var opts = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(name)
+            .Options;
+        return new AppDbContext(opts);
+    }
+
+    private static CollectionController CreateController(AppDbContext ctx, string userId = "user-1")
+    {
+        var claims = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.NameIdentifier, userId),
+        ], "test"));
+
+        return new CollectionController(ctx)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = claims }
+            }
+        };
+    }
+
+    private static Coffee SeedCoffee(AppDbContext ctx, int id = 1)
+    {
+        var coffee = new Coffee
+        {
+            Id = id, Name = $"Coffee {id}", ProcessingMethod = ProcessingMethod.Washed,
+            Species = Species.Arabica, RoastLevel = 2.5m, IsBlend = false,
+            IsActive = true, CreatedAt = DateTime.UtcNow,
+        };
+        ctx.Coffees.Add(coffee);
+        ctx.SaveChanges();
+        return coffee;
+    }
+
+    private static Grinder SeedGrinder(AppDbContext ctx, int id = 1)
+    {
+        var grinder = new Grinder
+        {
+            Id = id, Brand = "Baratza", Model = "Encore",
+            GrindType = GrindType.Stepped, BurrType = BurrType.Conical,
+            ScaleType = ScaleType.Numeric, ScaleMin = 1, ScaleMax = 40,
+            IsVerified = true,
+        };
+        ctx.Grinders.Add(grinder);
+        ctx.SaveChanges();
+        return grinder;
+    }
+
+    // ── My Shelf ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void AddToShelf_NewCoffee_ReturnsOk()
+    {
+        using var ctx = CreateDb(nameof(AddToShelf_NewCoffee_ReturnsOk));
+        SeedCoffee(ctx);
+        var ctrl = CreateController(ctx);
+
+        var result = ctrl.AddToShelf(1);
+
+        Assert.IsType<OkResult>(result);
+        Assert.Single(ctx.UserCoffees);
+    }
+
+    [Fact]
+    public void AddToShelf_Duplicate_IsIdempotent()
+    {
+        using var ctx = CreateDb(nameof(AddToShelf_Duplicate_IsIdempotent));
+        SeedCoffee(ctx);
+        var ctrl = CreateController(ctx);
+
+        ctrl.AddToShelf(1);
+        var result = ctrl.AddToShelf(1); // second call
+
+        Assert.IsType<OkResult>(result);
+        Assert.Single(ctx.UserCoffees); // still only one entry
+    }
+
+    [Fact]
+    public void AddToShelf_CoffeeNotFound_ReturnsNotFound()
+    {
+        using var ctx = CreateDb(nameof(AddToShelf_CoffeeNotFound_ReturnsNotFound));
+        var ctrl = CreateController(ctx);
+
+        var result = ctrl.AddToShelf(999);
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public void RemoveFromShelf_ExistingEntry_RemovesAndReturnsNoContent()
+    {
+        using var ctx = CreateDb(nameof(RemoveFromShelf_ExistingEntry_RemovesAndReturnsNoContent));
+        SeedCoffee(ctx);
+        var ctrl = CreateController(ctx);
+        ctrl.AddToShelf(1);
+
+        var result = ctrl.RemoveFromShelf(1);
+
+        Assert.IsType<NoContentResult>(result);
+        Assert.Empty(ctx.UserCoffees);
+    }
+
+    [Fact]
+    public void RemoveFromShelf_NotOnShelf_ReturnsNoContent()
+    {
+        using var ctx = CreateDb(nameof(RemoveFromShelf_NotOnShelf_ReturnsNoContent));
+        var ctrl = CreateController(ctx);
+
+        var result = ctrl.RemoveFromShelf(1);
+
+        Assert.IsType<NoContentResult>(result);
+    }
+
+    [Fact]
+    public void GetShelf_ReturnsOnlyCurrentUserItems()
+    {
+        using var ctx = CreateDb(nameof(GetShelf_ReturnsOnlyCurrentUserItems));
+        SeedCoffee(ctx, 1);
+        SeedCoffee(ctx, 2);
+
+        var ctrl1 = CreateController(ctx, "user-1");
+        var ctrl2 = CreateController(ctx, "user-2");
+        ctrl1.AddToShelf(1);
+        ctrl2.AddToShelf(2);
+
+        var result = ctrl1.GetShelf() as OkObjectResult;
+        var items = result!.Value as IEnumerable<UserCoffee>;
+
+        Assert.Single(items!);
+        Assert.Equal(1, items!.First().CoffeeId);
+    }
+
+    // ── My Setup — Grinders ───────────────────────────────────────────────────
+
+    [Fact]
+    public void AddGrinderToSetup_NewGrinder_ReturnsOk()
+    {
+        using var ctx = CreateDb(nameof(AddGrinderToSetup_NewGrinder_ReturnsOk));
+        SeedGrinder(ctx);
+        var ctrl = CreateController(ctx);
+
+        var result = ctrl.AddGrinderToSetup(1);
+
+        Assert.IsType<OkResult>(result);
+        Assert.Single(ctx.UserGrinders);
+    }
+
+    [Fact]
+    public void AddGrinderToSetup_Duplicate_IsIdempotent()
+    {
+        using var ctx = CreateDb(nameof(AddGrinderToSetup_Duplicate_IsIdempotent));
+        SeedGrinder(ctx);
+        var ctrl = CreateController(ctx);
+
+        ctrl.AddGrinderToSetup(1);
+        ctrl.AddGrinderToSetup(1);
+
+        Assert.Single(ctx.UserGrinders);
+    }
+
+    [Fact]
+    public void RemoveGrinderFromSetup_Existing_RemovesAndReturnsNoContent()
+    {
+        using var ctx = CreateDb(nameof(RemoveGrinderFromSetup_Existing_RemovesAndReturnsNoContent));
+        SeedGrinder(ctx);
+        var ctrl = CreateController(ctx);
+        ctrl.AddGrinderToSetup(1);
+
+        var result = ctrl.RemoveGrinderFromSetup(1);
+
+        Assert.IsType<NoContentResult>(result);
+        Assert.Empty(ctx.UserGrinders);
+    }
+
+    // ── My Setup — Brew Methods ───────────────────────────────────────────────
+
+    [Fact]
+    public void AddBrewMethodToSetup_New_ReturnsOk()
+    {
+        using var ctx = CreateDb(nameof(AddBrewMethodToSetup_New_ReturnsOk));
+        var ctrl = CreateController(ctx);
+
+        var result = ctrl.AddBrewMethodToSetup(BrewMethod.PourOver);
+
+        Assert.IsType<OkResult>(result);
+        Assert.Single(ctx.UserBrewMethods);
+    }
+
+    [Fact]
+    public void AddBrewMethodToSetup_Duplicate_IsIdempotent()
+    {
+        using var ctx = CreateDb(nameof(AddBrewMethodToSetup_Duplicate_IsIdempotent));
+        var ctrl = CreateController(ctx);
+
+        ctrl.AddBrewMethodToSetup(BrewMethod.PourOver);
+        ctrl.AddBrewMethodToSetup(BrewMethod.PourOver);
+
+        Assert.Single(ctx.UserBrewMethods);
+    }
+
+    [Fact]
+    public void GetSetupBrewMethods_ReturnsOnlyCurrentUser()
+    {
+        using var ctx = CreateDb(nameof(GetSetupBrewMethods_ReturnsOnlyCurrentUser));
+        var ctrl1 = CreateController(ctx, "user-1");
+        var ctrl2 = CreateController(ctx, "user-2");
+
+        ctrl1.AddBrewMethodToSetup(BrewMethod.PourOver);
+        ctrl1.AddBrewMethodToSetup(BrewMethod.Espresso);
+        ctrl2.AddBrewMethodToSetup(BrewMethod.FrenchPress);
+
+        var result = ctrl1.GetSetupBrewMethods() as OkObjectResult;
+        var items = result!.Value as IEnumerable<UserBrewMethod>;
+
+        Assert.Equal(2, items!.Count());
+    }
+
+    // ── Bag Tracking ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void OpenBag_ValidCoffee_CreatesBag()
+    {
+        using var ctx = CreateDb(nameof(OpenBag_ValidCoffee_CreatesBag));
+        SeedCoffee(ctx);
+        var ctrl = CreateController(ctx);
+
+        var result = ctrl.OpenBag(new OpenCoffeeBagRequest(1, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-10)), 250m, null));
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Single(ctx.CoffeeBags);
+    }
+
+    [Fact]
+    public void OpenBag_CoffeeNotFound_ReturnsNotFound()
+    {
+        using var ctx = CreateDb(nameof(OpenBag_CoffeeNotFound_ReturnsNotFound));
+        var ctrl = CreateController(ctx);
+
+        var result = ctrl.OpenBag(new OpenCoffeeBagRequest(999, null, null, null));
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public void GetFreshness_WashedCoffee_PeakDay7To21()
+    {
+        using var ctx = CreateDb(nameof(GetFreshness_WashedCoffee_PeakDay7To21));
+        var coffee = SeedCoffee(ctx);
+        var ctrl = CreateController(ctx);
+
+        // Coffee roasted 14 days ago → should be "Peak" for Washed (7–21 days)
+        ctrl.OpenBag(new OpenCoffeeBagRequest(1, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-14)), 250m, null));
+        var bag = ctx.CoffeeBags.First();
+
+        var result = ctrl.GetFreshness(bag.Id) as OkObjectResult;
+        var freshness = result!.Value as FreshnessInfo;
+
+        Assert.Equal("Peak", freshness!.FreshnessStatus);
+        Assert.Equal(7, freshness.PeakStartDay);
+        Assert.Equal(21, freshness.PeakEndDay);
+    }
+
+    [Fact]
+    public void GetFreshness_TooFreshCoffee_ReturnsCorrectStatus()
+    {
+        using var ctx = CreateDb(nameof(GetFreshness_TooFreshCoffee_ReturnsCorrectStatus));
+        SeedCoffee(ctx);
+        var ctrl = CreateController(ctx);
+
+        // Roasted only 3 days ago → "Too Fresh"
+        ctrl.OpenBag(new OpenCoffeeBagRequest(1, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-3)), 250m, null));
+        var bag = ctx.CoffeeBags.First();
+
+        var result = ctrl.GetFreshness(bag.Id) as OkObjectResult;
+        var freshness = result!.Value as FreshnessInfo;
+
+        Assert.Equal("Too Fresh", freshness!.FreshnessStatus);
+    }
+
+    [Fact]
+    public void GetFreshness_PastPeakCoffee_ReturnsCorrectStatus()
+    {
+        using var ctx = CreateDb(nameof(GetFreshness_PastPeakCoffee_ReturnsCorrectStatus));
+        SeedCoffee(ctx);
+        var ctrl = CreateController(ctx);
+
+        // Roasted 60 days ago → "Past Peak"
+        ctrl.OpenBag(new OpenCoffeeBagRequest(1, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-60)), 250m, null));
+        var bag = ctx.CoffeeBags.First();
+
+        var result = ctrl.GetFreshness(bag.Id) as OkObjectResult;
+        var freshness = result!.Value as FreshnessInfo;
+
+        Assert.Equal("Past Peak", freshness!.FreshnessStatus);
+    }
+
+    [Fact]
+    public void CloseBag_ExistingBag_RemovesIt()
+    {
+        using var ctx = CreateDb(nameof(CloseBag_ExistingBag_RemovesIt));
+        SeedCoffee(ctx);
+        var ctrl = CreateController(ctx);
+        ctrl.OpenBag(new OpenCoffeeBagRequest(1, null, null, null));
+        var bagId = ctx.CoffeeBags.First().Id;
+
+        var result = ctrl.CloseBag(bagId);
+
+        Assert.IsType<NoContentResult>(result);
+        Assert.Empty(ctx.CoffeeBags);
+    }
+
+    [Fact]
+    public void GetFreshness_OtherUser_ReturnsNotFound()
+    {
+        using var ctx = CreateDb(nameof(GetFreshness_OtherUser_ReturnsNotFound));
+        SeedCoffee(ctx);
+        var ctrl1 = CreateController(ctx, "user-1");
+        var ctrl2 = CreateController(ctx, "user-2");
+
+        ctrl1.OpenBag(new OpenCoffeeBagRequest(1, null, null, null));
+        var bagId = ctx.CoffeeBags.First().Id;
+
+        var result = ctrl2.GetFreshness(bagId);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+}

--- a/backend/GrindAtlas.API.Tests/GrindAtlas.API.Tests.csproj
+++ b/backend/GrindAtlas.API.Tests/GrindAtlas.API.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GrindAtlas.API\GrindAtlas.API.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/backend/GrindAtlas.API.Tests/GrindLogControllerTests.cs
+++ b/backend/GrindAtlas.API.Tests/GrindLogControllerTests.cs
@@ -1,0 +1,168 @@
+using GrindAtlas.API.Controllers;
+using GrindAtlas.API.Data;
+using GrindAtlas.API.DTOs;
+using GrindAtlas.API.Models;
+using GrindAtlas.API.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+
+namespace GrindAtlas.API.Tests;
+
+public class GrindLogControllerTests
+{
+    private static AppDbContext CreateDb(string name)
+    {
+        var opts = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(name)
+            .Options;
+        return new AppDbContext(opts);
+    }
+
+    private static GrindLogsController CreateController(AppDbContext ctx, string userId = "user-1")
+    {
+        var claims = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(ClaimTypes.NameIdentifier, userId),
+        ], "test"));
+
+        var estimator = new GrindEstimatorService(ctx);
+
+        return new GrindLogsController(ctx, estimator)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = claims }
+            }
+        };
+    }
+
+    private static void SeedCoffeeAndGrinder(AppDbContext ctx)
+    {
+        ctx.Coffees.Add(new Coffee
+        {
+            Id = 1, Name = "Test Coffee", ProcessingMethod = ProcessingMethod.Washed,
+            Species = Species.Arabica, RoastLevel = 2.5m, IsBlend = false,
+            IsActive = true, CreatedAt = DateTime.UtcNow,
+        });
+        ctx.Grinders.Add(new Grinder
+        {
+            Id = 1, Brand = "Baratza", Model = "Encore",
+            GrindType = GrindType.Stepped, BurrType = BurrType.Conical,
+            ScaleType = ScaleType.Numeric, ScaleMin = 1, ScaleMax = 40, IsVerified = true,
+        });
+        ctx.GrinderCalibrations.Add(new GrinderCalibration
+        {
+            GrinderId = 1, BrewMethod = BrewMethod.PourOver,
+            NativeSetting = 20m, NgiValue = 50m,
+        });
+        ctx.SaveChanges();
+    }
+
+    [Fact]
+    public void Create_ValidRequest_ReturnsOk()
+    {
+        using var ctx = CreateDb(nameof(Create_ValidRequest_ReturnsOk));
+        SeedCoffeeAndGrinder(ctx);
+        var ctrl = CreateController(ctx);
+
+        var req = new AddGrindLogRequest(1, 1, BrewMethod.PourOver, 20m, 15m, 250m, 210, 4, null, null, null);
+        var result = ctrl.Create(req);
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Single(ctx.GrindLogs);
+    }
+
+    [Fact]
+    public void Create_DuplicateRecipeToday_ReturnsConflict()
+    {
+        using var ctx = CreateDb(nameof(Create_DuplicateRecipeToday_ReturnsConflict));
+        SeedCoffeeAndGrinder(ctx);
+        var ctrl = CreateController(ctx);
+
+        var req = new AddGrindLogRequest(1, 1, BrewMethod.PourOver, 20m, 15m, 250m, 210, 4, null, null, RecipeId: 5);
+        ctrl.Create(req); // first save
+
+        var result = ctrl.Create(req); // duplicate
+
+        Assert.IsType<ConflictObjectResult>(result);
+        Assert.Single(ctx.GrindLogs); // only one log saved
+    }
+
+    [Fact]
+    public void Create_DuplicateWithNoRecipeId_AllowsMultiple()
+    {
+        // Duplicate detection only applies when RecipeId is set
+        using var ctx = CreateDb(nameof(Create_DuplicateWithNoRecipeId_AllowsMultiple));
+        SeedCoffeeAndGrinder(ctx);
+        var ctrl = CreateController(ctx);
+
+        var req = new AddGrindLogRequest(1, 1, BrewMethod.PourOver, 20m, 15m, 250m, 210, 4, null, null, null);
+        ctrl.Create(req);
+        ctrl.Create(req); // no recipeId → no duplicate check
+
+        Assert.Equal(2, ctx.GrindLogs.Count());
+    }
+
+    [Fact]
+    public void Create_WithExtractionFeedback_SavesField()
+    {
+        using var ctx = CreateDb(nameof(Create_WithExtractionFeedback_SavesField));
+        SeedCoffeeAndGrinder(ctx);
+        var ctrl = CreateController(ctx);
+
+        var req = new AddGrindLogRequest(1, 1, BrewMethod.PourOver, 20m, 15m, 250m, 210, 4, ExtractionFeedback: 2, null, null);
+        ctrl.Create(req);
+
+        Assert.Equal(2, ctx.GrindLogs.First().ExtractionFeedback);
+    }
+
+    [Fact]
+    public void Create_ExtractionFeedbackOutOfRange_ReturnsBadRequest()
+    {
+        using var ctx = CreateDb(nameof(Create_ExtractionFeedbackOutOfRange_ReturnsBadRequest));
+        SeedCoffeeAndGrinder(ctx);
+        var ctrl = CreateController(ctx);
+
+        var req = new AddGrindLogRequest(1, 1, BrewMethod.PourOver, 20m, 15m, 250m, 210, 4, ExtractionFeedback: 5, null, null);
+        var result = ctrl.Create(req);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Empty(ctx.GrindLogs);
+    }
+
+    [Fact]
+    public void Create_SameRecipeDifferentUser_AllowsBoth()
+    {
+        using var ctx = CreateDb(nameof(Create_SameRecipeDifferentUser_AllowsBoth));
+        SeedCoffeeAndGrinder(ctx);
+        var ctrl1 = CreateController(ctx, "user-1");
+        var ctrl2 = CreateController(ctx, "user-2");
+
+        var req = new AddGrindLogRequest(1, 1, BrewMethod.PourOver, 20m, 15m, 250m, 210, 4, null, null, RecipeId: 1);
+        ctrl1.Create(req);
+        ctrl2.Create(req);
+
+        Assert.Equal(2, ctx.GrindLogs.Count());
+    }
+
+    [Fact]
+    public void GetAll_ReturnsOnlyCurrentUserLogs()
+    {
+        using var ctx = CreateDb(nameof(GetAll_ReturnsOnlyCurrentUserLogs));
+        SeedCoffeeAndGrinder(ctx);
+        var ctrl1 = CreateController(ctx, "user-1");
+        var ctrl2 = CreateController(ctx, "user-2");
+
+        var req = new AddGrindLogRequest(1, 1, BrewMethod.PourOver, 20m, null, null, null, null, null, null, null);
+        ctrl1.Create(req);
+        ctrl1.Create(req);
+        ctrl2.Create(req);
+
+        var result = ctrl1.GetAll(null, null) as OkObjectResult;
+        var logs = result!.Value as IEnumerable<GrindLog>;
+
+        Assert.Equal(2, logs!.Count());
+    }
+}

--- a/backend/GrindAtlas.API/Controllers/CollectionController.cs
+++ b/backend/GrindAtlas.API/Controllers/CollectionController.cs
@@ -1,0 +1,234 @@
+using GrindAtlas.API.Data;
+using GrindAtlas.API.DTOs;
+using GrindAtlas.API.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+
+namespace GrindAtlas.API.Controllers;
+
+// ── Collection: My Shelf + My Setup + Bag Tracking ───────────────────────────
+[ApiController, Route("api/collection")]
+[Authorize]
+public class CollectionController(AppDbContext ctx) : ControllerBase
+{
+    private string UserId => User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+
+    // ── My Shelf (coffees) ────────────────────────────────────────────────────
+
+    [HttpGet("coffees")]
+    public IActionResult GetShelf()
+    {
+        var items = ctx.UserCoffees
+            .Where(uc => uc.UserId == UserId)
+            .Include(uc => uc.Coffee)
+            .OrderBy(uc => uc.Coffee.Name)
+            .ToList();
+        return Ok(items);
+    }
+
+    [HttpPost("coffees/{coffeeId:int}")]
+    public IActionResult AddToShelf(int coffeeId)
+    {
+        if (!ctx.Coffees.Any(c => c.Id == coffeeId))
+            return NotFound("Coffee not found.");
+
+        var exists = ctx.UserCoffees.Any(uc => uc.UserId == UserId && uc.CoffeeId == coffeeId);
+        if (exists) return Ok(); // idempotent
+
+        ctx.UserCoffees.Add(new UserCoffee { UserId = UserId, CoffeeId = coffeeId });
+        ctx.SaveChanges();
+        return Ok();
+    }
+
+    [HttpDelete("coffees/{coffeeId:int}")]
+    public IActionResult RemoveFromShelf(int coffeeId)
+    {
+        var entry = ctx.UserCoffees.FirstOrDefault(uc => uc.UserId == UserId && uc.CoffeeId == coffeeId);
+        if (entry is null) return NoContent();
+        ctx.UserCoffees.Remove(entry);
+        ctx.SaveChanges();
+        return NoContent();
+    }
+
+    // ── My Setup (grinders) ───────────────────────────────────────────────────
+
+    [HttpGet("grinders")]
+    public IActionResult GetSetupGrinders()
+    {
+        var items = ctx.UserGrinders
+            .Where(ug => ug.UserId == UserId)
+            .Include(ug => ug.Grinder).ThenInclude(g => g.Calibrations)
+            .OrderBy(ug => ug.Grinder.Brand)
+            .ToList();
+        return Ok(items);
+    }
+
+    [HttpPost("grinders/{grinderId:int}")]
+    public IActionResult AddGrinderToSetup(int grinderId)
+    {
+        if (!ctx.Grinders.Any(g => g.Id == grinderId))
+            return NotFound("Grinder not found.");
+
+        var exists = ctx.UserGrinders.Any(ug => ug.UserId == UserId && ug.GrinderId == grinderId);
+        if (exists) return Ok();
+
+        ctx.UserGrinders.Add(new UserGrinder { UserId = UserId, GrinderId = grinderId });
+        ctx.SaveChanges();
+        return Ok();
+    }
+
+    [HttpDelete("grinders/{grinderId:int}")]
+    public IActionResult RemoveGrinderFromSetup(int grinderId)
+    {
+        var entry = ctx.UserGrinders.FirstOrDefault(ug => ug.UserId == UserId && ug.GrinderId == grinderId);
+        if (entry is null) return NoContent();
+        ctx.UserGrinders.Remove(entry);
+        ctx.SaveChanges();
+        return NoContent();
+    }
+
+    // ── My Setup (brew methods) ───────────────────────────────────────────────
+
+    [HttpGet("brewmethods")]
+    public IActionResult GetSetupBrewMethods()
+    {
+        var items = ctx.UserBrewMethods
+            .Where(ubm => ubm.UserId == UserId)
+            .OrderBy(ubm => ubm.BrewMethod)
+            .ToList();
+        return Ok(items);
+    }
+
+    [HttpPost("brewmethods/{method}")]
+    public IActionResult AddBrewMethodToSetup(BrewMethod method)
+    {
+        var exists = ctx.UserBrewMethods.Any(ubm => ubm.UserId == UserId && ubm.BrewMethod == method);
+        if (exists) return Ok();
+
+        ctx.UserBrewMethods.Add(new UserBrewMethod { UserId = UserId, BrewMethod = method });
+        ctx.SaveChanges();
+        return Ok();
+    }
+
+    [HttpDelete("brewmethods/{method}")]
+    public IActionResult RemoveBrewMethodFromSetup(BrewMethod method)
+    {
+        var entry = ctx.UserBrewMethods.FirstOrDefault(ubm => ubm.UserId == UserId && ubm.BrewMethod == method);
+        if (entry is null) return NoContent();
+        ctx.UserBrewMethods.Remove(entry);
+        ctx.SaveChanges();
+        return NoContent();
+    }
+
+    // ── Bag Tracking ──────────────────────────────────────────────────────────
+
+    [HttpGet("bags")]
+    public IActionResult GetBags()
+    {
+        var bags = ctx.CoffeeBags
+            .Where(b => b.UserId == UserId)
+            .Include(b => b.Coffee)
+            .OrderByDescending(b => b.OpenedAt)
+            .ToList();
+        return Ok(bags);
+    }
+
+    [HttpPost("bags")]
+    public IActionResult OpenBag(OpenCoffeeBagRequest req)
+    {
+        if (!ctx.Coffees.Any(c => c.Id == req.CoffeeId))
+            return NotFound("Coffee not found.");
+
+        var bag = new CoffeeBag
+        {
+            UserId    = UserId,
+            CoffeeId  = req.CoffeeId,
+            OpenedAt  = DateTime.UtcNow,
+            RoastedOn = req.RoastedOn,
+            BagWeightG = req.BagWeightG,
+            Notes      = req.Notes?.Trim(),
+        };
+        ctx.CoffeeBags.Add(bag);
+        ctx.SaveChanges();
+        return Ok(bag);
+    }
+
+    [HttpDelete("bags/{bagId:int}")]
+    public IActionResult CloseBag(int bagId)
+    {
+        var bag = ctx.CoffeeBags.FirstOrDefault(b => b.Id == bagId && b.UserId == UserId);
+        if (bag is null) return NotFound();
+        ctx.CoffeeBags.Remove(bag);
+        ctx.SaveChanges();
+        return NoContent();
+    }
+
+    [HttpGet("bags/{bagId:int}/freshness")]
+    public IActionResult GetFreshness(int bagId)
+    {
+        var bag = ctx.CoffeeBags
+            .Include(b => b.Coffee)
+            .FirstOrDefault(b => b.Id == bagId && b.UserId == UserId);
+        if (bag is null) return NotFound();
+
+        // Compute freshness window based on processing method
+        var (peakStart, peakEnd) = GetFreshnessWindow(bag.Coffee.ProcessingMethod);
+
+        int? daysSinceRoast = null;
+        string freshnessStatus = "Unknown";
+
+        if (bag.RoastedOn.HasValue)
+        {
+            daysSinceRoast = (DateOnly.FromDateTime(DateTime.UtcNow).DayNumber - bag.RoastedOn.Value.DayNumber);
+            freshnessStatus = daysSinceRoast < peakStart ? "Too Fresh"
+                : daysSinceRoast <= peakEnd  ? "Peak"
+                : daysSinceRoast <= peakEnd + 14 ? "Acceptable"
+                : "Past Peak";
+        }
+
+        // Usage rate: total dose from grind logs since bag opened
+        var logsAfterOpen = ctx.GrindLogs
+            .Where(l => l.UserId == UserId && l.CoffeeId == bag.CoffeeId
+                        && l.CreatedAt >= bag.OpenedAt)
+            .ToList();
+
+        decimal totalDoseG = logsAfterOpen.Sum(l => l.DoseG ?? 0);
+        double daysSinceOpen = Math.Max(1, (DateTime.UtcNow - bag.OpenedAt).TotalDays);
+        decimal? usageRate = totalDoseG > 0 ? Math.Round((decimal)(totalDoseG / (decimal)daysSinceOpen), 1) : null;
+
+        decimal? daysRemaining = null;
+        bool isRunningLow = false;
+        if (bag.BagWeightG.HasValue && usageRate.HasValue && usageRate > 0)
+        {
+            var remaining = bag.BagWeightG.Value - totalDoseG;
+            daysRemaining = Math.Max(0, Math.Round(remaining / usageRate.Value, 0));
+            isRunningLow = daysRemaining <= 7;
+        }
+
+        return Ok(new FreshnessInfo(
+            bag.Id,
+            bag.CoffeeId,
+            bag.Coffee.Name,
+            bag.OpenedAt,
+            bag.RoastedOn,
+            daysSinceRoast,
+            freshnessStatus,
+            peakStart,
+            peakEnd,
+            usageRate,
+            daysRemaining,
+            isRunningLow
+        ));
+    }
+
+    private static (int PeakStart, int PeakEnd) GetFreshnessWindow(ProcessingMethod method) => method switch
+    {
+        ProcessingMethod.Natural   => (14, 35),
+        ProcessingMethod.Honey     => (10, 28),
+        ProcessingMethod.Anaerobic => (14, 42),
+        ProcessingMethod.WetHulled => (7, 21),
+        _                          => (7, 21),  // Washed and Other
+    };
+}

--- a/backend/GrindAtlas.API/Controllers/Controllers.cs
+++ b/backend/GrindAtlas.API/Controllers/Controllers.cs
@@ -115,24 +115,41 @@ public class GrindLogsController(AppDbContext ctx, GrindEstimatorService estimat
     public IActionResult Create(AddGrindLogRequest req)
     {
         var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        // Duplicate detection: same recipe + user + today
+        if (req.RecipeId.HasValue)
+        {
+            var duplicate = ctx.GrindLogs.Any(l =>
+                l.UserId == userId &&
+                l.RecipeId == req.RecipeId &&
+                l.BrewDate == today);
+            if (duplicate)
+                return Conflict("A session for this recipe was already saved today. Remove the existing log first if you want to re-save.");
+        }
+
+        if (req.ExtractionFeedback.HasValue && (req.ExtractionFeedback < -3 || req.ExtractionFeedback > 3))
+            return BadRequest("ExtractionFeedback must be between -3 and 3.");
+
         var notes = string.IsNullOrWhiteSpace(req.Notes) ? null : req.Notes.Trim();
         var ngi = estimator.NativeToNgi(req.NativeSetting, req.GrinderId);
         var log = new GrindLog
         {
-            CoffeeId         = req.CoffeeId,
-            GrinderId        = req.GrinderId,
-            BrewMethod       = req.BrewMethod,
-            NativeSetting    = req.NativeSetting,
-            NgiNormalized    = ngi,
-            DoseG            = req.DoseG,
-            YieldG           = req.YieldG,
-            ExtractionTimeS  = req.ExtractionTimeS,
-            Rating           = req.Rating,
-            Notes            = notes,
-            RecipeId         = req.RecipeId,
-            BrewDate         = DateOnly.FromDateTime(DateTime.UtcNow),
-            CreatedAt        = DateTime.UtcNow,
-            UserId           = userId,
+            CoffeeId           = req.CoffeeId,
+            GrinderId          = req.GrinderId,
+            BrewMethod         = req.BrewMethod,
+            NativeSetting      = req.NativeSetting,
+            NgiNormalized      = ngi,
+            DoseG              = req.DoseG,
+            YieldG             = req.YieldG,
+            ExtractionTimeS    = req.ExtractionTimeS,
+            Rating             = req.Rating,
+            ExtractionFeedback = req.ExtractionFeedback,
+            Notes              = notes,
+            RecipeId           = req.RecipeId,
+            BrewDate           = today,
+            CreatedAt          = DateTime.UtcNow,
+            UserId             = userId,
         };
         ctx.GrindLogs.Add(log);
         ctx.SaveChanges();

--- a/backend/GrindAtlas.API/DTOs/Dtos.cs
+++ b/backend/GrindAtlas.API/DTOs/Dtos.cs
@@ -39,8 +39,31 @@ public record AddGrindLogRequest(
     decimal? YieldG,
     int? ExtractionTimeS,
     int? Rating,
+    int? ExtractionFeedback,  // -3 (very under) to +3 (very over)
     string? Notes,
     int? RecipeId
+);
+
+public record OpenCoffeeBagRequest(
+    int CoffeeId,
+    DateOnly? RoastedOn,
+    decimal? BagWeightG,
+    string? Notes
+);
+
+public record FreshnessInfo(
+    int BagId,
+    int CoffeeId,
+    string CoffeeName,
+    DateTime OpenedAt,
+    DateOnly? RoastedOn,
+    int? DaysSinceRoast,
+    string FreshnessStatus,   // "Too Fresh" | "Peak" | "Acceptable" | "Past Peak"
+    int? PeakStartDay,
+    int? PeakEndDay,
+    decimal? UsageRateGPerDay,
+    decimal? EstimatedDaysRemaining,
+    bool IsRunningLow
 );
 
 public record ConfirmEstimateRequest(decimal ConfirmedSetting);

--- a/backend/GrindAtlas.API/Data/AppDbContext.cs
+++ b/backend/GrindAtlas.API/Data/AppDbContext.cs
@@ -13,6 +13,10 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : IdentityDbCo
     public DbSet<BrewRecipe> BrewRecipes => Set<BrewRecipe>();
     public DbSet<BrewRecipeStep> BrewRecipeSteps => Set<BrewRecipeStep>();
     public DbSet<GrindEstimate> GrindEstimates => Set<GrindEstimate>();
+    public DbSet<UserCoffee> UserCoffees => Set<UserCoffee>();
+    public DbSet<UserGrinder> UserGrinders => Set<UserGrinder>();
+    public DbSet<UserBrewMethod> UserBrewMethods => Set<UserBrewMethod>();
+    public DbSet<CoffeeBag> CoffeeBags => Set<CoffeeBag>();
 
     protected override void OnModelCreating(ModelBuilder mb)
     {
@@ -24,5 +28,9 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : IdentityDbCo
         mb.Entity<GrindEstimate>().Property(e => e.AvgSimilarityScore).HasPrecision(4, 3);
         mb.Entity<GrinderCalibration>().Property(c => c.NativeSetting).HasPrecision(6, 2);
         mb.Entity<GrindEstimate>().Property(e => e.ConfidenceScore).HasPrecision(4, 3);
+        mb.Entity<CoffeeBag>().Property(b => b.BagWeightG).HasPrecision(6, 1);
+        mb.Entity<UserCoffee>().HasIndex(uc => new { uc.UserId, uc.CoffeeId }).IsUnique();
+        mb.Entity<UserGrinder>().HasIndex(ug => new { ug.UserId, ug.GrinderId }).IsUnique();
+        mb.Entity<UserBrewMethod>().HasIndex(ubm => new { ubm.UserId, ubm.BrewMethod }).IsUnique();
     }
 }

--- a/backend/GrindAtlas.API/Models/Collection.cs
+++ b/backend/GrindAtlas.API/Models/Collection.cs
@@ -1,0 +1,47 @@
+namespace GrindAtlas.API.Models;
+
+public class UserCoffee
+{
+    public int Id { get; set; }
+    public string UserId { get; set; } = "";
+    public int CoffeeId { get; set; }
+    public DateTime AddedAt { get; set; } = DateTime.UtcNow;
+
+    public ApplicationUser User { get; set; } = null!;
+    public Coffee Coffee { get; set; } = null!;
+}
+
+public class UserGrinder
+{
+    public int Id { get; set; }
+    public string UserId { get; set; } = "";
+    public int GrinderId { get; set; }
+    public DateTime AddedAt { get; set; } = DateTime.UtcNow;
+
+    public ApplicationUser User { get; set; } = null!;
+    public Grinder Grinder { get; set; } = null!;
+}
+
+public class UserBrewMethod
+{
+    public int Id { get; set; }
+    public string UserId { get; set; } = "";
+    public BrewMethod BrewMethod { get; set; }
+    public DateTime AddedAt { get; set; } = DateTime.UtcNow;
+
+    public ApplicationUser User { get; set; } = null!;
+}
+
+public class CoffeeBag
+{
+    public int Id { get; set; }
+    public string UserId { get; set; } = "";
+    public int CoffeeId { get; set; }
+    public DateTime OpenedAt { get; set; } = DateTime.UtcNow;
+    public DateOnly? RoastedOn { get; set; }
+    public decimal? BagWeightG { get; set; }
+    public string? Notes { get; set; }
+
+    public ApplicationUser User { get; set; } = null!;
+    public Coffee Coffee { get; set; } = null!;
+}

--- a/backend/GrindAtlas.API/Models/GrindLog.cs
+++ b/backend/GrindAtlas.API/Models/GrindLog.cs
@@ -13,6 +13,7 @@ public class GrindLog
     public int? ExtractionTimeS { get; set; }
     public decimal? TdsPercent { get; set; }
     public int? Rating { get; set; }               // 1–5
+    public int? ExtractionFeedback { get; set; }   // -3 (very under) to +3 (very over)
     public string? Notes { get; set; }
     public DateOnly? BrewDate { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/frontend/grind-atlas-ui/src/app/app.component.ts
+++ b/frontend/grind-atlas-ui/src/app/app.component.ts
@@ -54,12 +54,15 @@ const SHELL_HIDDEN_ROUTES = ['/', '/login', '/register', '/not-found'];
             role="navigation"
             aria-label="Main navigation">
             <div class="sidebar-section" aria-hidden="true">Navigation</div>
-            <a class="sidebar-item" routerLink="/home"         routerLinkActive="active" (click)="closeSidebar()">Home</a>
-            <a class="sidebar-item" routerLink="/grind-advisor" routerLinkActive="active" (click)="closeSidebar()">Grind Advisor</a>
-            <a class="sidebar-item" routerLink="/coffees"      routerLinkActive="active" (click)="closeSidebar()">Coffees</a>
-            <a class="sidebar-item" routerLink="/grinders"     routerLinkActive="active" (click)="closeSidebar()">Grinders</a>
-            <a class="sidebar-item" routerLink="/logs"         routerLinkActive="active" (click)="closeSidebar()">My Logs</a>
-            <a class="sidebar-item" routerLink="/recipes"      routerLinkActive="active" (click)="closeSidebar()">Recipes</a>
+            <a class="sidebar-item" routerLink="/home"             routerLinkActive="active" (click)="closeSidebar()">Home</a>
+            <a class="sidebar-item" routerLink="/grind-advisor"    routerLinkActive="active" (click)="closeSidebar()">Grind Advisor</a>
+            <a class="sidebar-item" routerLink="/coffees"          routerLinkActive="active" (click)="closeSidebar()">Coffees</a>
+            <a class="sidebar-item" routerLink="/grinders"         routerLinkActive="active" (click)="closeSidebar()">Grinders</a>
+            <a class="sidebar-item" routerLink="/logs"             routerLinkActive="active" (click)="closeSidebar()">My Logs</a>
+            <a class="sidebar-item" routerLink="/recipes"          routerLinkActive="active" (click)="closeSidebar()">Recipes</a>
+            <div class="sidebar-section" aria-hidden="true">Collection</div>
+            <a class="sidebar-item" routerLink="/collection/shelf" routerLinkActive="active" (click)="closeSidebar()">My Shelf</a>
+            <a class="sidebar-item" routerLink="/collection/setup" routerLinkActive="active" (click)="closeSidebar()">My Setup</a>
           </nav>
         }
         <main id="main-content" [class]="showShell() ? 'main' : 'main-full'" tabindex="-1">

--- a/frontend/grind-atlas-ui/src/app/app.routes.ts
+++ b/frontend/grind-atlas-ui/src/app/app.routes.ts
@@ -76,6 +76,18 @@ export const routes: Routes = [
     canDeactivate: [brewGuard],
   },
   {
+    path: 'collection/shelf',
+    loadComponent: () =>
+      import('./components/collection/my-shelf.component').then(m => m.MyShelfComponent),
+    canActivate: [authGuard],
+  },
+  {
+    path: 'collection/setup',
+    loadComponent: () =>
+      import('./components/collection/my-setup.component').then(m => m.MySetupComponent),
+    canActivate: [authGuard],
+  },
+  {
     path: 'login',
     loadComponent: () =>
       import('./components/auth/login.component').then(m => m.LoginComponent),

--- a/frontend/grind-atlas-ui/src/app/components/coffees/coffees.component.ts
+++ b/frontend/grind-atlas-ui/src/app/components/coffees/coffees.component.ts
@@ -2,7 +2,8 @@ import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
-import { CoffeeService } from '../../services/services';
+import { forkJoin } from 'rxjs';
+import { CoffeeService, CollectionService } from '../../services/services';
 import { Coffee, ProcessingMethod } from '../../models/models';
 
 @Component({
@@ -69,17 +70,39 @@ import { Coffee, ProcessingMethod } from '../../models/models';
             <th scope="col">Roast</th>
             <th scope="col">Variety</th>
             <th scope="col">Notes</th>
+            <th scope="col"><span class="sr-only">Shelf</span></th>
           </tr>
         </thead>
         <tbody>
           <tr *ngFor="let c of filteredCoffees">
-            <td><strong>{{ c.name }}</strong></td>
+            <td>
+              <strong>{{ c.name }}</strong>
+              <span *ngIf="shelfIds.has(c.id)" class="status-pill s-active" style="margin-left:6px; font-size:9px;" aria-label="On your shelf">Shelf</span>
+            </td>
             <td>{{ c.roaster }}</td>
             <td>{{ c.originRegion ? c.originRegion + ', ' : '' }}{{ c.originCountry }}</td>
             <td><span class="status-pill">{{ c.processingMethod }}</span></td>
             <td>{{ roastLabel(c.roastLevel) }} ({{ c.roastLevel }})</td>
             <td style="color:#666;">{{ c.variety || '—' }}</td>
             <td style="max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:#666;">{{ c.tastingNotes || '—' }}</td>
+            <td>
+              <button
+                *ngIf="!shelfIds.has(c.id)"
+                class="btn btn-sm"
+                (click)="addToShelf(c)"
+                [disabled]="pendingShelfId === c.id"
+                [attr.aria-label]="'Add ' + c.name + ' to shelf'">
+                + Shelf
+              </button>
+              <button
+                *ngIf="shelfIds.has(c.id)"
+                class="btn btn-sm"
+                (click)="removeFromShelf(c)"
+                [disabled]="pendingShelfId === c.id"
+                [attr.aria-label]="'Remove ' + c.name + ' from shelf'">
+                − Shelf
+              </button>
+            </td>
           </tr>
           <tr *ngIf="filteredCoffees.length === 0">
             <td colspan="7" style="text-align:center; color:#999; padding:20px;">No coffees match the current filters.</td>
@@ -91,10 +114,13 @@ import { Coffee, ProcessingMethod } from '../../models/models';
   `,
 })
 export class CoffeesComponent implements OnInit {
-  private coffeeService = inject(CoffeeService);
+  private coffeeService     = inject(CoffeeService);
+  private collectionService = inject(CollectionService);
 
   allCoffees:      Coffee[] = [];
   filteredCoffees: Coffee[] = [];
+  shelfIds = new Set<number>();
+  pendingShelfId?: number;
   loading = true;
 
   search           = '';
@@ -106,10 +132,37 @@ export class CoffeesComponent implements OnInit {
   processingMethods: ProcessingMethod[] = ['Washed', 'Natural', 'Honey', 'Anaerobic', 'WetHulled', 'Other'];
 
   ngOnInit() {
-    this.coffeeService.getAll().subscribe(c => {
-      this.allCoffees = c;
-      this.filteredCoffees = c;
-      this.loading = false;
+    forkJoin({
+      coffees: this.coffeeService.getAll(),
+      shelf:   this.collectionService.getShelf(),
+    }).subscribe({
+      next: ({ coffees, shelf }) => {
+        this.allCoffees      = coffees;
+        this.filteredCoffees = coffees;
+        this.shelfIds        = new Set(shelf.map(s => s.coffeeId));
+        this.loading         = false;
+      },
+      error: () => {
+        this.coffeeService.getAll().subscribe(c => {
+          this.allCoffees = c; this.filteredCoffees = c; this.loading = false;
+        });
+      },
+    });
+  }
+
+  addToShelf(coffee: Coffee): void {
+    this.pendingShelfId = coffee.id;
+    this.collectionService.addToShelf(coffee.id).subscribe({
+      next:  () => { this.shelfIds.add(coffee.id); this.pendingShelfId = undefined; },
+      error: () => { this.pendingShelfId = undefined; },
+    });
+  }
+
+  removeFromShelf(coffee: Coffee): void {
+    this.pendingShelfId = coffee.id;
+    this.collectionService.removeFromShelf(coffee.id).subscribe({
+      next:  () => { this.shelfIds.delete(coffee.id); this.pendingShelfId = undefined; },
+      error: () => { this.pendingShelfId = undefined; },
     });
   }
 

--- a/frontend/grind-atlas-ui/src/app/components/collection/my-setup.component.ts
+++ b/frontend/grind-atlas-ui/src/app/components/collection/my-setup.component.ts
@@ -1,0 +1,355 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { forkJoin, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { CollectionService, GrinderService } from '../../services/services';
+import {
+  UserGrinder,
+  UserBrewMethod,
+  Grinder,
+  BrewMethod,
+  BREW_METHOD_LABELS,
+} from '../../models/models';
+
+const ALL_BREW_METHODS: BrewMethod[] = [
+  'Espresso',
+  'MokaPot',
+  'AeropressFine',
+  'AeropressCoarse',
+  'PourOver',
+  'Chemex',
+  'FrenchPress',
+  'ColdBrew',
+  'Siphon',
+];
+
+@Component({
+  selector: 'app-my-setup',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  template: `
+    <h1 class="page-title">My Setup</h1>
+
+    <!-- Loading state -->
+    <div
+      *ngIf="loading"
+      style="font-size:12px; color:#666; padding:20px 0;"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true">
+      Loading your setup…
+    </div>
+
+    <!-- Error state -->
+    <div
+      *ngIf="error && !loading"
+      class="error-msg"
+      role="alert"
+      aria-live="assertive">
+      {{ error }}
+    </div>
+
+    <div *ngIf="!loading">
+
+      <!-- ── My Grinders ─────────────────────────────────────────── -->
+      <section aria-labelledby="grinders-heading" style="margin-bottom:32px;">
+        <div style="display:flex; align-items:baseline; justify-content:space-between; margin-bottom:14px;">
+          <h2 class="section-label" id="grinders-heading" style="margin-bottom:0;">My Grinders</h2>
+        </div>
+
+        <!-- Empty state -->
+        <p
+          *ngIf="setupGrinders.length === 0"
+          style="font-size:13px; color:#999; margin:0 0 16px;">
+          No grinders in your setup.
+        </p>
+
+        <!-- Grinder cards -->
+        <div
+          *ngIf="setupGrinders.length > 0"
+          class="grid-2"
+          style="margin-bottom:16px;"
+          role="list"
+          aria-label="Your grinders">
+
+          <article
+            *ngFor="let ug of setupGrinders"
+            class="panel"
+            role="listitem"
+            [attr.aria-label]="ug.grinder.brand + ' ' + ug.grinder.model">
+
+            <div class="panel-head">
+              <span class="panel-title">{{ ug.grinder.brand }} {{ ug.grinder.model }}</span>
+              <button
+                class="btn btn-sm"
+                (click)="removeGrinder(ug)"
+                [disabled]="removingGrinderIds.has(ug.grinderId)"
+                [attr.aria-label]="'Remove ' + ug.grinder.brand + ' ' + ug.grinder.model + ' from setup'"
+                style="min-width:44px; min-height:44px;">
+                {{ removingGrinderIds.has(ug.grinderId) ? 'Removing…' : 'Remove' }}
+              </button>
+            </div>
+
+            <div class="panel-body">
+              <div style="display:flex; gap:6px; flex-wrap:wrap;">
+                <span
+                  class="status-pill"
+                  aria-label="Grind type">
+                  {{ ug.grinder.grindType }}
+                </span>
+                <span
+                  class="status-pill"
+                  aria-label="Burr type">
+                  {{ ug.grinder.burrType }}
+                </span>
+                <span
+                  *ngIf="ug.grinder.burrSizeMm"
+                  class="status-pill"
+                  aria-label="Burr size">
+                  {{ ug.grinder.burrSizeMm }}mm
+                </span>
+              </div>
+            </div>
+          </article>
+        </div>
+
+        <!-- Add grinder row -->
+        <div
+          class="panel"
+          role="region"
+          aria-label="Add a grinder to your setup">
+          <div class="panel-head">
+            <span class="panel-title">Add Grinder</span>
+          </div>
+          <div class="panel-body" style="display:flex; gap:10px; flex-wrap:wrap; align-items:flex-end;">
+            <div class="form-group" style="margin-bottom:0; flex:1; min-width:200px;">
+              <label class="form-label" for="grinder-select">Select Grinder</label>
+              <select
+                id="grinder-select"
+                [(ngModel)]="selectedGrinderId"
+                [disabled]="availableGrinders.length === 0"
+                aria-label="Choose a grinder to add to your setup"
+                style="font-size:16px;">
+                <option [ngValue]="null">
+                  {{ availableGrinders.length === 0 ? 'All grinders added' : 'Select grinder…' }}
+                </option>
+                <option *ngFor="let g of availableGrinders" [ngValue]="g.id">
+                  {{ g.brand }} {{ g.model }}
+                </option>
+              </select>
+            </div>
+            <button
+              class="btn btn-inv"
+              (click)="addGrinder()"
+              [disabled]="selectedGrinderId === null || addingGrinder"
+              aria-label="Add selected grinder to your setup"
+              style="min-width:44px; min-height:44px;">
+              {{ addingGrinder ? 'Adding…' : 'Add' }}
+            </button>
+          </div>
+          <div
+            *ngIf="grinderError"
+            class="error-msg"
+            role="alert"
+            style="margin:0 18px 16px;">
+            {{ grinderError }}
+          </div>
+        </div>
+      </section>
+
+      <!-- ── My Brew Methods ─────────────────────────────────────── -->
+      <section aria-labelledby="brew-methods-heading">
+        <div style="margin-bottom:14px;">
+          <h2 class="section-label" id="brew-methods-heading" style="margin-bottom:0;">My Brew Methods</h2>
+        </div>
+
+        <div
+          *ngIf="brewMethodsLoading"
+          style="font-size:12px; color:#666;"
+          role="status"
+          aria-live="polite">
+          Loading brew methods…
+        </div>
+
+        <div
+          class="panel"
+          *ngIf="!brewMethodsLoading">
+          <div class="panel-head">
+            <span class="panel-title">Toggle Brew Methods</span>
+            <span
+              class="section-label"
+              style="margin-bottom:0;"
+              aria-live="polite"
+              aria-atomic="true">
+              {{ selectedBrewMethods.size }} selected
+            </span>
+          </div>
+          <div
+            class="panel-body"
+            style="display:flex; flex-wrap:wrap; gap:10px;"
+            role="group"
+            aria-labelledby="brew-methods-heading">
+
+            <button
+              *ngFor="let method of allBrewMethods"
+              class="btn"
+              [class.btn-inv]="selectedBrewMethods.has(method)"
+              (click)="toggleBrewMethod(method)"
+              [disabled]="togglingBrewMethods.has(method)"
+              [attr.aria-pressed]="selectedBrewMethods.has(method)"
+              [attr.aria-label]="getBrewMethodLabel(method) + (selectedBrewMethods.has(method) ? ' (selected, click to remove)' : ' (click to add)')"
+              style="min-width:44px; min-height:44px;">
+              {{ getBrewMethodLabel(method) }}
+            </button>
+          </div>
+
+          <div
+            *ngIf="brewMethodError"
+            class="error-msg"
+            role="alert"
+            style="margin:0 18px 16px;">
+            {{ brewMethodError }}
+          </div>
+        </div>
+      </section>
+
+    </div>
+  `,
+})
+export class MySetupComponent implements OnInit {
+  private collectionService = inject(CollectionService);
+  private grinderService = inject(GrinderService);
+
+  setupGrinders: UserGrinder[] = [];
+  allGrinders: Grinder[] = [];
+  selectedBrewMethods = new Set<BrewMethod>();
+
+  loading = true;
+  brewMethodsLoading = false;
+  error: string | null = null;
+  grinderError: string | null = null;
+  brewMethodError: string | null = null;
+
+  selectedGrinderId: number | null = null;
+  addingGrinder = false;
+  removingGrinderIds = new Set<number>();
+  togglingBrewMethods = new Set<BrewMethod>();
+
+  readonly allBrewMethods: BrewMethod[] = ALL_BREW_METHODS;
+  readonly brewMethodLabels = BREW_METHOD_LABELS;
+
+  get availableGrinders(): Grinder[] {
+    const ownedIds = new Set(this.setupGrinders.map(ug => ug.grinderId));
+    return this.allGrinders.filter(g => !ownedIds.has(g.id));
+  }
+
+  ngOnInit(): void {
+    forkJoin({
+      setupGrinders: this.collectionService.getSetupGrinders().pipe(
+        catchError(() => of([] as UserGrinder[]))
+      ),
+      allGrinders: this.grinderService.getAll().pipe(
+        catchError(() => of([] as Grinder[]))
+      ),
+      brewMethods: this.collectionService.getSetupBrewMethods().pipe(
+        catchError(() => of([] as UserBrewMethod[]))
+      ),
+    }).subscribe({
+      next: ({ setupGrinders, allGrinders, brewMethods }) => {
+        this.setupGrinders = setupGrinders;
+        this.allGrinders = allGrinders;
+        this.selectedBrewMethods = new Set(brewMethods.map(bm => bm.brewMethod));
+        this.loading = false;
+      },
+      error: () => {
+        this.error = 'Failed to load your setup. Please try again.';
+        this.loading = false;
+      },
+    });
+  }
+
+  addGrinder(): void {
+    if (this.selectedGrinderId === null) return;
+
+    const grinderId = this.selectedGrinderId;
+    this.addingGrinder = true;
+    this.grinderError = null;
+
+    this.collectionService.addGrinderToSetup(grinderId).subscribe({
+      next: () => {
+        const grinder = this.allGrinders.find(g => g.id === grinderId);
+        if (grinder) {
+          const newUserGrinder: UserGrinder = {
+            id: Date.now(),
+            userId: '',
+            grinderId: grinder.id,
+            addedAt: new Date().toISOString(),
+            grinder,
+          };
+          this.setupGrinders = [...this.setupGrinders, newUserGrinder];
+        }
+        this.selectedGrinderId = null;
+        this.addingGrinder = false;
+      },
+      error: () => {
+        this.addingGrinder = false;
+        this.grinderError = 'Failed to add grinder. Please try again.';
+      },
+    });
+  }
+
+  removeGrinder(ug: UserGrinder): void {
+    this.removingGrinderIds.add(ug.grinderId);
+    this.grinderError = null;
+
+    this.collectionService.removeGrinderFromSetup(ug.grinderId).subscribe({
+      next: () => {
+        this.setupGrinders = this.setupGrinders.filter(g => g.grinderId !== ug.grinderId);
+        this.removingGrinderIds.delete(ug.grinderId);
+      },
+      error: () => {
+        this.removingGrinderIds.delete(ug.grinderId);
+        this.grinderError = `Failed to remove ${ug.grinder.brand} ${ug.grinder.model}. Please try again.`;
+      },
+    });
+  }
+
+  toggleBrewMethod(method: BrewMethod): void {
+    const wasSelected = this.selectedBrewMethods.has(method);
+    this.brewMethodError = null;
+
+    // Optimistic update
+    if (wasSelected) {
+      this.selectedBrewMethods.delete(method);
+    } else {
+      this.selectedBrewMethods.add(method);
+    }
+    this.togglingBrewMethods.add(method);
+
+    const request$ = wasSelected
+      ? this.collectionService.removeBrewMethodFromSetup(method)
+      : this.collectionService.addBrewMethodToSetup(method);
+
+    request$.subscribe({
+      next: () => {
+        this.togglingBrewMethods.delete(method);
+      },
+      error: () => {
+        // Rollback optimistic update
+        if (wasSelected) {
+          this.selectedBrewMethods.add(method);
+        } else {
+          this.selectedBrewMethods.delete(method);
+        }
+        this.togglingBrewMethods.delete(method);
+        this.brewMethodError = `Failed to ${wasSelected ? 'remove' : 'add'} ${BREW_METHOD_LABELS[method]}. Please try again.`;
+      },
+    });
+  }
+
+  getBrewMethodLabel(method: BrewMethod): string {
+    return BREW_METHOD_LABELS[method];
+  }
+}

--- a/frontend/grind-atlas-ui/src/app/components/collection/my-shelf.component.ts
+++ b/frontend/grind-atlas-ui/src/app/components/collection/my-shelf.component.ts
@@ -1,0 +1,402 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { forkJoin, of, Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { CollectionService, CoffeeService } from '../../services/services';
+import {
+  UserCoffee,
+  Coffee,
+  CoffeeBag,
+  OpenCoffeeBagRequest,
+  FreshnessInfo,
+} from '../../models/models';
+
+interface OpenBagForm {
+  roastedOn: string;
+  bagWeightG: number | null;
+  notes: string;
+}
+
+@Component({
+  selector: 'app-my-shelf',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  template: `
+    <h1 class="page-title">My Shelf</h1>
+
+    <!-- Loading state -->
+    <div
+      *ngIf="loading"
+      style="font-size:12px; color:#666; padding:20px 0;"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true">
+      Loading your shelf…
+    </div>
+
+    <!-- Error state -->
+    <div
+      *ngIf="error && !loading"
+      class="error-msg"
+      role="alert"
+      aria-live="assertive">
+      {{ error }}
+    </div>
+
+    <!-- Empty state -->
+    <div
+      *ngIf="!loading && !error && shelfItems.length === 0"
+      class="panel"
+      role="status">
+      <div class="panel-body" style="text-align:center; padding:40px 20px; color:#666;">
+        Your shelf is empty.
+        <a routerLink="/coffees" class="btn" style="margin-top:16px; display:inline-block;">Browse Coffees</a>
+        to add some.
+      </div>
+    </div>
+
+    <!-- Shelf grid -->
+    <div
+      *ngIf="!loading && !error && shelfItems.length > 0"
+      class="grid-2"
+      role="list"
+      aria-label="Your coffee shelf">
+
+      <article
+        *ngFor="let item of shelfItems"
+        class="panel"
+        role="listitem"
+        [attr.aria-label]="item.coffee.name + ' by ' + (item.coffee.roaster || 'Unknown Roaster')">
+
+        <!-- Card header -->
+        <div class="panel-head">
+          <span class="panel-title">{{ item.coffee.name }}</span>
+          <button
+            class="btn btn-sm"
+            (click)="removeFromShelf(item)"
+            [disabled]="removingIds.has(item.coffeeId)"
+            [attr.aria-label]="'Remove ' + item.coffee.name + ' from shelf'"
+            style="min-width:44px; min-height:44px;">
+            {{ removingIds.has(item.coffeeId) ? 'Removing…' : 'Remove' }}
+          </button>
+        </div>
+
+        <div class="panel-body">
+          <!-- Coffee metadata -->
+          <div style="margin-bottom:14px;">
+            <div style="font-size:13px; color:#666; margin-bottom:6px;">
+              {{ item.coffee.roaster || 'Unknown Roaster' }}
+            </div>
+            <div style="display:flex; flex-wrap:wrap; gap:6px; align-items:center;">
+              <span class="status-pill" aria-label="Processing method">{{ item.coffee.processingMethod }}</span>
+              <span class="status-pill" aria-label="Roast level">{{ roastLabel(item.coffee.roastLevel) }}</span>
+            </div>
+          </div>
+
+          <!-- Bag tracking section -->
+          <section [attr.aria-label]="'Bag tracking for ' + item.coffee.name">
+            <div class="section-label">Bags</div>
+
+            <!-- Open bags for this coffee -->
+            <ng-container *ngIf="getOpenBagsForCoffee(item.coffeeId).length > 0; else noBags">
+              <div
+                *ngFor="let bag of getOpenBagsForCoffee(item.coffeeId)"
+                style="border:1.5px solid var(--ink); padding:12px; margin-bottom:10px; background:var(--paper);"
+                [attr.aria-label]="'Open bag opened on ' + (bag.openedAt | date:'mediumDate')">
+
+                <div style="display:flex; justify-content:space-between; align-items:flex-start; gap:8px; flex-wrap:wrap;">
+                  <div>
+                    <div style="font-size:12px; color:#666; margin-bottom:6px;">
+                      Opened {{ bag.openedAt | date:'mediumDate' }}
+                      <span *ngIf="bag.roastedOn"> · Roasted {{ bag.roastedOn | date:'mediumDate' }}</span>
+                      <span *ngIf="bag.bagWeightG"> · {{ bag.bagWeightG }}g</span>
+                    </div>
+
+                    <!-- Freshness pill -->
+                    <ng-container *ngIf="freshnessMap.get(bag.id) as freshness">
+                      <span
+                        class="status-pill"
+                        [class.s-active]="freshness.freshnessStatus === 'Peak'"
+                        [class.s-hold]="freshness.freshnessStatus === 'Acceptable'"
+                        [attr.aria-label]="'Freshness: ' + freshness.freshnessStatus">
+                        {{ freshness.freshnessStatus }}
+                      </span>
+                      <span
+                        *ngIf="freshness.isRunningLow"
+                        style="font-size:11px; font-weight:700; color:#c00; margin-left:8px; letter-spacing:0.08em; text-transform:uppercase;"
+                        role="alert"
+                        aria-live="polite">
+                        Running Low
+                      </span>
+                    </ng-container>
+                    <ng-container *ngIf="freshnessLoadingIds.has(bag.id)">
+                      <span style="font-size:11px; color:#666;">Loading freshness…</span>
+                    </ng-container>
+                  </div>
+
+                  <button
+                    class="btn btn-sm"
+                    (click)="closeBag(bag)"
+                    [disabled]="closingBagIds.has(bag.id)"
+                    [attr.aria-label]="'Close bag opened on ' + (bag.openedAt | date:'mediumDate')"
+                    style="min-width:44px; min-height:44px; flex-shrink:0;">
+                    {{ closingBagIds.has(bag.id) ? 'Closing…' : 'Close Bag' }}
+                  </button>
+                </div>
+
+                <div *ngIf="bag.notes" style="font-size:12px; color:#666; margin-top:8px; font-style:italic;">
+                  {{ bag.notes }}
+                </div>
+              </div>
+            </ng-container>
+
+            <!-- No open bag state + open bag button -->
+            <ng-template #noBags>
+              <p style="font-size:12px; color:#999; margin:0 0 10px;">No open bag for this coffee.</p>
+            </ng-template>
+
+            <!-- Open Bag button (shown when no inline form active for this coffee) -->
+            <div *ngIf="openBagFormCoffeeId !== item.coffeeId">
+              <button
+                class="btn btn-sm"
+                (click)="showOpenBagForm(item.coffeeId)"
+                [attr.aria-label]="'Open a new bag of ' + item.coffee.name"
+                style="min-width:44px; min-height:44px;">
+                Open Bag
+              </button>
+            </div>
+
+            <!-- Inline Open Bag form -->
+            <div
+              *ngIf="openBagFormCoffeeId === item.coffeeId"
+              style="border:1.5px solid var(--ink); padding:14px; background:var(--paper); margin-top:8px;"
+              role="region"
+              [attr.aria-label]="'Open new bag form for ' + item.coffee.name">
+
+              <div class="section-label" style="margin-bottom:10px;">Open New Bag</div>
+
+              <div class="form-group">
+                <label class="form-label" [for]="'roasted-on-' + item.coffeeId">Roasted On</label>
+                <input
+                  [id]="'roasted-on-' + item.coffeeId"
+                  type="date"
+                  [(ngModel)]="openBagForm.roastedOn"
+                  [attr.aria-label]="'Roast date for new bag of ' + item.coffee.name"
+                  style="font-size:16px;">
+              </div>
+
+              <div class="form-group">
+                <label class="form-label" [for]="'bag-weight-' + item.coffeeId">Bag Weight (g)</label>
+                <input
+                  [id]="'bag-weight-' + item.coffeeId"
+                  type="number"
+                  [(ngModel)]="openBagForm.bagWeightG"
+                  min="1"
+                  placeholder="e.g. 250"
+                  [attr.aria-label]="'Bag weight in grams for ' + item.coffee.name"
+                  style="font-size:16px;">
+              </div>
+
+              <div class="form-group">
+                <label class="form-label" [for]="'bag-notes-' + item.coffeeId">Notes</label>
+                <input
+                  [id]="'bag-notes-' + item.coffeeId"
+                  type="text"
+                  [(ngModel)]="openBagForm.notes"
+                  placeholder="Optional notes…"
+                  [attr.aria-label]="'Notes for new bag of ' + item.coffee.name"
+                  style="font-size:16px;">
+              </div>
+
+              <div style="display:flex; gap:8px; flex-wrap:wrap;">
+                <button
+                  class="btn btn-inv"
+                  (click)="submitOpenBag(item.coffeeId)"
+                  [disabled]="openingBag"
+                  [attr.aria-label]="'Confirm open new bag of ' + item.coffee.name"
+                  style="min-width:44px; min-height:44px;">
+                  {{ openingBag ? 'Opening…' : 'Open' }}
+                </button>
+                <button
+                  class="btn"
+                  (click)="cancelOpenBagForm()"
+                  [attr.aria-label]="'Cancel opening new bag of ' + item.coffee.name"
+                  style="min-width:44px; min-height:44px;">
+                  Cancel
+                </button>
+              </div>
+
+              <div
+                *ngIf="openBagError"
+                class="error-msg"
+                role="alert"
+                style="margin-top:10px;">
+                {{ openBagError }}
+              </div>
+            </div>
+          </section>
+        </div>
+      </article>
+    </div>
+  `,
+})
+export class MyShelfComponent implements OnInit {
+  private collectionService = inject(CollectionService);
+  private coffeeService = inject(CoffeeService);
+
+  shelfItems: UserCoffee[] = [];
+  allCoffees: Coffee[] = [];
+  bags: CoffeeBag[] = [];
+  freshnessMap = new Map<number, FreshnessInfo>();
+
+  loading = true;
+  error: string | null = null;
+
+  removingIds = new Set<number>();
+  closingBagIds = new Set<number>();
+  freshnessLoadingIds = new Set<number>();
+
+  // Open bag inline form state
+  openBagFormCoffeeId: number | null = null;
+  openBagForm: OpenBagForm = { roastedOn: '', bagWeightG: null, notes: '' };
+  openingBag = false;
+  openBagError: string | null = null;
+
+  ngOnInit(): void {
+    forkJoin({
+      shelf: this.collectionService.getShelf().pipe(
+        catchError(() => of([] as UserCoffee[]))
+      ),
+      bags: this.collectionService.getBags().pipe(
+        catchError(() => of([] as CoffeeBag[]))
+      ),
+      coffees: this.coffeeService.getAll().pipe(
+        catchError(() => of([] as Coffee[]))
+      ),
+    }).subscribe({
+      next: ({ shelf, bags, coffees }) => {
+        this.shelfItems = shelf;
+        this.bags = bags;
+        this.allCoffees = coffees;
+        this.loading = false;
+        this.loadFreshnessForAllBags(bags);
+      },
+      error: () => {
+        this.error = 'Failed to load your shelf. Please try again.';
+        this.loading = false;
+      },
+    });
+  }
+
+  private loadFreshnessForAllBags(bags: CoffeeBag[]): void {
+    if (bags.length === 0) return;
+
+    bags.forEach(bag => this.freshnessLoadingIds.add(bag.id));
+
+    const freshnessRequests = bags.reduce((acc, bag) => {
+      acc[bag.id] = this.collectionService.getBagFreshness(bag.id).pipe(
+        catchError(() => of(null as FreshnessInfo | null))
+      );
+      return acc;
+    }, {} as Record<number, Observable<FreshnessInfo | null>>);
+
+    forkJoin(freshnessRequests).subscribe(results => {
+      Object.entries(results).forEach(([bagIdStr, info]) => {
+        const bagId = Number(bagIdStr);
+        this.freshnessLoadingIds.delete(bagId);
+        if (info) {
+          this.freshnessMap.set(bagId, info as FreshnessInfo);
+        }
+      });
+    });
+  }
+
+  getOpenBagsForCoffee(coffeeId: number): CoffeeBag[] {
+    return this.bags.filter(b => b.coffeeId === coffeeId);
+  }
+
+  removeFromShelf(item: UserCoffee): void {
+    this.removingIds.add(item.coffeeId);
+    this.collectionService.removeFromShelf(item.coffeeId).subscribe({
+      next: () => {
+        this.shelfItems = this.shelfItems.filter(s => s.coffeeId !== item.coffeeId);
+        this.removingIds.delete(item.coffeeId);
+      },
+      error: () => {
+        this.removingIds.delete(item.coffeeId);
+        this.error = `Failed to remove ${item.coffee.name} from shelf.`;
+      },
+    });
+  }
+
+  closeBag(bag: CoffeeBag): void {
+    this.closingBagIds.add(bag.id);
+    this.collectionService.closeBag(bag.id).subscribe({
+      next: () => {
+        this.bags = this.bags.filter(b => b.id !== bag.id);
+        this.freshnessMap.delete(bag.id);
+        this.closingBagIds.delete(bag.id);
+      },
+      error: () => {
+        this.closingBagIds.delete(bag.id);
+        this.error = 'Failed to close bag. Please try again.';
+      },
+    });
+  }
+
+  showOpenBagForm(coffeeId: number): void {
+    this.openBagFormCoffeeId = coffeeId;
+    this.openBagForm = { roastedOn: '', bagWeightG: null, notes: '' };
+    this.openBagError = null;
+  }
+
+  cancelOpenBagForm(): void {
+    this.openBagFormCoffeeId = null;
+    this.openBagError = null;
+  }
+
+  submitOpenBag(coffeeId: number): void {
+    this.openingBag = true;
+    this.openBagError = null;
+
+    const req: OpenCoffeeBagRequest = {
+      coffeeId,
+      roastedOn: this.openBagForm.roastedOn || undefined,
+      bagWeightG: this.openBagForm.bagWeightG ?? undefined,
+      notes: this.openBagForm.notes || undefined,
+    };
+
+    this.collectionService.openBag(req).subscribe({
+      next: (newBag) => {
+        this.bags = [...this.bags, newBag];
+        this.openBagFormCoffeeId = null;
+        this.openingBag = false;
+
+        // Load freshness for the newly opened bag
+        this.freshnessLoadingIds.add(newBag.id);
+        this.collectionService.getBagFreshness(newBag.id).pipe(
+          catchError(() => of(null as FreshnessInfo | null))
+        ).subscribe(info => {
+          this.freshnessLoadingIds.delete(newBag.id);
+          if (info) {
+            this.freshnessMap.set(newBag.id, info);
+          }
+        });
+      },
+      error: () => {
+        this.openingBag = false;
+        this.openBagError = 'Failed to open bag. Please try again.';
+      },
+    });
+  }
+
+  roastLabel(level: number): string {
+    if (level <= 1.5) return 'Light';
+    if (level <= 2.5) return 'Lt-Med';
+    if (level <= 3.5) return 'Medium';
+    if (level <= 4.0) return 'Med-Dark';
+    return 'Dark';
+  }
+}

--- a/frontend/grind-atlas-ui/src/app/components/grind-advisor/grind-advisor.component.ts
+++ b/frontend/grind-atlas-ui/src/app/components/grind-advisor/grind-advisor.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { CoffeeService, GrinderService, GrindAdvisorService } from '../../services/services';
+import { forkJoin } from 'rxjs';
+import { CoffeeService, GrinderService, GrindAdvisorService, CollectionService } from '../../services/services';
 import { Coffee, Grinder, EstimateResponse, BrewMethod, BREW_METHOD_LABELS } from '../../models/models';
 
 @Component({
@@ -22,25 +23,44 @@ import { Coffee, Grinder, EstimateResponse, BrewMethod, BREW_METHOD_LABELS } fro
             <label class="form-label" for="advisor-coffee">Coffee</label>
             <select id="advisor-coffee" [(ngModel)]="selectedCoffeeId" (ngModelChange)="onSelectionChange()">
               <option [ngValue]="undefined">Select coffee…</option>
-              <option *ngFor="let c of coffees" [ngValue]="c.id">
-                {{ c.name }} — {{ c.roaster }}
-              </option>
+              <optgroup *ngIf="shelfCoffees.length" label="My Shelf">
+                <option *ngFor="let c of shelfCoffees" [ngValue]="c.id">
+                  {{ c.name }} — {{ c.roaster }}
+                </option>
+              </optgroup>
+              <optgroup [label]="shelfCoffees.length ? 'All Coffees' : ''">
+                <option *ngFor="let c of otherCoffees" [ngValue]="c.id">
+                  {{ c.name }} — {{ c.roaster }}
+                </option>
+              </optgroup>
             </select>
           </div>
           <div class="form-group" style="margin-bottom: 0;">
             <label class="form-label" for="advisor-grinder">Target Grinder</label>
             <select id="advisor-grinder" [(ngModel)]="selectedGrinderId" (ngModelChange)="onSelectionChange()">
               <option [ngValue]="undefined">Select grinder…</option>
-              <option *ngFor="let g of grinders" [ngValue]="g.id">
-                {{ g.brand }} {{ g.model }}
-              </option>
+              <optgroup *ngIf="setupGrinders.length" label="My Setup">
+                <option *ngFor="let g of setupGrinders" [ngValue]="g.id">
+                  {{ g.brand }} {{ g.model }}
+                </option>
+              </optgroup>
+              <optgroup [label]="setupGrinders.length ? 'All Grinders' : ''">
+                <option *ngFor="let g of otherGrinders" [ngValue]="g.id">
+                  {{ g.brand }} {{ g.model }}
+                </option>
+              </optgroup>
             </select>
           </div>
           <div class="form-group" style="margin-bottom: 0;">
             <label class="form-label" for="advisor-brew-method">Brew Method</label>
             <select id="advisor-brew-method" [(ngModel)]="selectedBrewMethod" (ngModelChange)="onSelectionChange()">
               <option [ngValue]="undefined">Select method…</option>
-              <option *ngFor="let m of brewMethods" [ngValue]="m.value">{{ m.label }}</option>
+              <option *ngFor="let m of activeBrewMethods" [ngValue]="m.value">{{ m.label }}</option>
+              <ng-container *ngIf="fallbackBrewMethods.length">
+                <optgroup label="Other Methods">
+                  <option *ngFor="let m of fallbackBrewMethods" [ngValue]="m.value">{{ m.label }}</option>
+                </optgroup>
+              </ng-container>
             </select>
           </div>
         </div>
@@ -157,13 +177,33 @@ import { Coffee, Grinder, EstimateResponse, BrewMethod, BREW_METHOD_LABELS } fro
   `,
 })
 export class GrindAdvisorComponent implements OnInit {
-  private coffeeService      = inject(CoffeeService);
-  private grinderService     = inject(GrinderService);
+  private coffeeService       = inject(CoffeeService);
+  private grinderService      = inject(GrinderService);
   private grindAdvisorService = inject(GrindAdvisorService);
+  private collectionService   = inject(CollectionService);
 
-  coffees: Coffee[]   = [];
-  grinders: Grinder[] = [];
-  brewMethods = Object.entries(BREW_METHOD_LABELS).map(([value, label]) => ({ value: value as BrewMethod, label }));
+  allCoffees:  Coffee[]   = [];
+  allGrinders: Grinder[]  = [];
+  shelfCoffeeIds  = new Set<number>();
+  setupGrinderIds = new Set<number>();
+  setupBrewMethodValues = new Set<BrewMethod>();
+
+  allBrewMethods = Object.entries(BREW_METHOD_LABELS).map(([value, label]) => ({ value: value as BrewMethod, label }));
+
+  get shelfCoffees():  Coffee[]   { return this.allCoffees.filter(c => this.shelfCoffeeIds.has(c.id)); }
+  get otherCoffees():  Coffee[]   { return this.allCoffees.filter(c => !this.shelfCoffeeIds.has(c.id)); }
+  get setupGrinders(): Grinder[]  { return this.allGrinders.filter(g => this.setupGrinderIds.has(g.id)); }
+  get otherGrinders(): Grinder[]  { return this.allGrinders.filter(g => !this.setupGrinderIds.has(g.id)); }
+
+  get activeBrewMethods() {
+    if (this.setupBrewMethodValues.size === 0) return this.allBrewMethods;
+    return this.allBrewMethods.filter(m => this.setupBrewMethodValues.has(m.value));
+  }
+
+  get fallbackBrewMethods() {
+    if (this.setupBrewMethodValues.size === 0) return [];
+    return this.allBrewMethods.filter(m => !this.setupBrewMethodValues.has(m.value));
+  }
 
   selectedCoffeeId?: number;
   selectedGrinderId?: number;
@@ -179,18 +219,36 @@ export class GrindAdvisorComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.coffeeService.getAll().subscribe(c => this.coffees = c);
-    this.grinderService.getAll().subscribe(g => this.grinders = g);
+    forkJoin({
+      coffees:      this.coffeeService.getAll(),
+      grinders:     this.grinderService.getAll(),
+      shelf:        this.collectionService.getShelf(),
+      setupGrinders: this.collectionService.getSetupGrinders(),
+      setupMethods:  this.collectionService.getSetupBrewMethods(),
+    }).subscribe({
+      next: ({ coffees, grinders, shelf, setupGrinders, setupMethods }) => {
+        this.allCoffees  = coffees;
+        this.allGrinders = grinders;
+        this.shelfCoffeeIds  = new Set(shelf.map(s => s.coffeeId));
+        this.setupGrinderIds = new Set(setupGrinders.map(s => s.grinderId));
+        this.setupBrewMethodValues = new Set(setupMethods.map(s => s.brewMethod));
+      },
+      error: () => {
+        // Fallback: load coffees/grinders without collection data
+        this.coffeeService.getAll().subscribe(c => this.allCoffees = c);
+        this.grinderService.getAll().subscribe(g => this.allGrinders = g);
+      },
+    });
   }
 
   get selectedGrinder(): Grinder | undefined {
-    return this.grinders.find(g => g.id === this.selectedGrinderId);
+    return this.allGrinders.find(g => g.id === this.selectedGrinderId);
   }
 
   onSelectionChange() {
     this.result = undefined;
     this.error  = undefined;
-    this.selectedCoffee = this.coffees.find(c => c.id === this.selectedCoffeeId);
+    this.selectedCoffee = this.allCoffees.find(c => c.id === this.selectedCoffeeId);
   }
 
   formatNativeSetting(n: number): string {

--- a/frontend/grind-atlas-ui/src/app/components/grinders/grinders.component.ts
+++ b/frontend/grind-atlas-ui/src/app/components/grinders/grinders.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
-import { GrinderService } from '../../services/services';
+import { forkJoin } from 'rxjs';
+import { GrinderService, CollectionService } from '../../services/services';
 import { Grinder } from '../../models/models';
 
 @Component({
@@ -23,6 +24,7 @@ import { Grinder } from '../../models/models';
         <div class="panel-head">
           <h2 class="panel-title">{{ g.brand }} {{ g.model }}</h2>
           <span class="status-pill" [attr.aria-label]="'Burr type: ' + g.burrType">{{ g.burrType }}</span>
+          <span *ngIf="setupIds.has(g.id)" class="status-pill s-active" style="font-size:9px;" aria-label="In your setup">Setup</span>
         </div>
         <div class="panel-body">
           <dl style="display:flex; gap:24px; margin-bottom: 14px; flex-wrap:wrap;">
@@ -47,6 +49,26 @@ import { Grinder } from '../../models/models';
               <dd style="font-size:12px; margin:0;">{{ g.isVerified ? 'Yes' : 'No' }}</dd>
             </div>
           </dl>
+
+          <!-- Setup toggle -->
+          <div style="margin-bottom:12px;">
+            <button
+              *ngIf="!setupIds.has(g.id)"
+              class="btn btn-sm"
+              (click)="addToSetup(g)"
+              [disabled]="pendingSetupId === g.id"
+              [attr.aria-label]="'Add ' + g.brand + ' ' + g.model + ' to My Setup'">
+              + My Setup
+            </button>
+            <button
+              *ngIf="setupIds.has(g.id)"
+              class="btn btn-sm"
+              (click)="removeFromSetup(g)"
+              [disabled]="pendingSetupId === g.id"
+              [attr.aria-label]="'Remove ' + g.brand + ' ' + g.model + ' from My Setup'">
+              − My Setup
+            </button>
+          </div>
 
           <!-- Calibrations -->
           <div *ngIf="g.calibrations?.length">
@@ -80,11 +102,42 @@ import { Grinder } from '../../models/models';
   `,
 })
 export class GrindersComponent implements OnInit {
-  private grinderService = inject(GrinderService);
+  private grinderService    = inject(GrinderService);
+  private collectionService = inject(CollectionService);
+
   grinders: Grinder[] = [];
+  setupIds = new Set<number>();
+  pendingSetupId?: number;
 
   ngOnInit() {
-    this.grinderService.getAll().subscribe(g => this.grinders = g);
+    forkJoin({
+      grinders: this.grinderService.getAll(),
+      setup:    this.collectionService.getSetupGrinders(),
+    }).subscribe({
+      next: ({ grinders, setup }) => {
+        this.grinders = grinders;
+        this.setupIds = new Set(setup.map(s => s.grinderId));
+      },
+      error: () => {
+        this.grinderService.getAll().subscribe(g => this.grinders = g);
+      },
+    });
+  }
+
+  addToSetup(g: Grinder): void {
+    this.pendingSetupId = g.id;
+    this.collectionService.addGrinderToSetup(g.id).subscribe({
+      next:  () => { this.setupIds.add(g.id); this.pendingSetupId = undefined; },
+      error: () => { this.pendingSetupId = undefined; },
+    });
+  }
+
+  removeFromSetup(g: Grinder): void {
+    this.pendingSetupId = g.id;
+    this.collectionService.removeGrinderFromSetup(g.id).subscribe({
+      next:  () => { this.setupIds.delete(g.id); this.pendingSetupId = undefined; },
+      error: () => { this.pendingSetupId = undefined; },
+    });
   }
 
   formatBrewMethod(m: string): string {

--- a/frontend/grind-atlas-ui/src/app/components/recipes/recipe-brew.component.ts
+++ b/frontend/grind-atlas-ui/src/app/components/recipes/recipe-brew.component.ts
@@ -148,7 +148,7 @@ export const brewGuard: CanDeactivateFn<RecipeBrewComponent> = (component) => {
       </div>
 
       <!-- Brew complete + review form -->
-      <div *ngIf="isComplete" class="panel" style="margin-bottom:20px;">
+      <div *ngIf="isComplete && !saved" class="panel" style="margin-bottom:20px;">
         <div class="panel-head">
           <span class="panel-title">Brew Complete — {{ formatTime(elapsedTotal) }}</span>
         </div>
@@ -158,20 +158,20 @@ export const brewGuard: CanDeactivateFn<RecipeBrewComponent> = (component) => {
           </p>
           <div class="form-grid-3" style="margin-bottom:14px;">
             <div class="form-group" style="margin-bottom:0;">
-              <label class="form-label">Dose (g)</label>
-              <input type="number" [(ngModel)]="review.doseG" step="0.1" placeholder="e.g. 15">
+              <label class="form-label" for="review-dose">Dose (g)</label>
+              <input id="review-dose" type="number" [(ngModel)]="review.doseG" step="0.1" placeholder="e.g. 15">
             </div>
             <div class="form-group" style="margin-bottom:0;">
-              <label class="form-label">Yield (g)</label>
-              <input type="number" [(ngModel)]="review.yieldG" step="0.1" placeholder="e.g. 250">
+              <label class="form-label" for="review-yield">Yield (g)</label>
+              <input id="review-yield" type="number" [(ngModel)]="review.yieldG" step="0.1" placeholder="e.g. 250">
             </div>
             <div class="form-group" style="margin-bottom:0;">
-              <label class="form-label">Extraction Time (s)</label>
-              <input type="number" [(ngModel)]="review.extractionTimeS" placeholder="e.g. 210">
+              <label class="form-label" for="review-time">Extraction Time (s)</label>
+              <input id="review-time" type="number" [(ngModel)]="review.extractionTimeS" placeholder="e.g. 210">
             </div>
             <div class="form-group" style="margin-bottom:0;">
-              <label class="form-label">Rating (1–5)</label>
-              <select [(ngModel)]="review.rating">
+              <label class="form-label" for="review-rating">Rating (1–5)</label>
+              <select id="review-rating" [(ngModel)]="review.rating">
                 <option [ngValue]="undefined">—</option>
                 <option [ngValue]="1">1</option>
                 <option [ngValue]="2">2</option>
@@ -181,19 +181,60 @@ export const brewGuard: CanDeactivateFn<RecipeBrewComponent> = (component) => {
               </select>
             </div>
             <div class="form-group" style="margin-bottom:0; grid-column:span 2;">
-              <label class="form-label">Notes</label>
-              <input type="text" [(ngModel)]="review.notes" placeholder="Observations from this brew…">
+              <label class="form-label" for="review-notes">Notes</label>
+              <input id="review-notes" type="text" [(ngModel)]="review.notes" placeholder="Observations from this brew…">
             </div>
           </div>
 
+          <!-- Extraction Feedback Slider -->
+          <div class="form-group" style="margin-bottom:14px;">
+            <label class="form-label" for="extraction-slider">
+              Extraction — {{ extractionLabel }}
+            </label>
+            <div style="display:flex; align-items:center; gap:10px;">
+              <span style="font-size:11px; color:#666; white-space:nowrap;">Under</span>
+              <input
+                id="extraction-slider"
+                type="range"
+                min="-3" max="3" step="1"
+                [(ngModel)]="review.extractionFeedback"
+                style="flex:1; accent-color:var(--ink);"
+                [attr.aria-valuetext]="extractionLabel">
+              <span style="font-size:11px; color:#666; white-space:nowrap;">Over</span>
+            </div>
+            <div style="display:flex; justify-content:space-between; font-size:10px; color:#999; margin-top:3px;">
+              <span>-3</span><span>-2</span><span>-1</span><span>0</span><span>+1</span><span>+2</span><span>+3</span>
+            </div>
+          </div>
+
+          <div *ngIf="saveError" role="alert" style="font-size:12px; color:#c00; margin-bottom:12px; border:1px solid #c00; padding:8px 12px;">
+            {{ saveError }}
+          </div>
+
           <div style="display:flex; gap:12px; align-items:center;">
-            <button class="btn btn-inv" (click)="saveReview()" [disabled]="!canSaveReview || saving">
+            <button class="btn btn-inv" (click)="saveReview()" [disabled]="!canSaveReview || saving" [attr.aria-busy]="saving">
               {{ saving ? 'Saving…' : 'Save Session' }}
             </button>
             <a routerLink="/recipes" class="btn btn-sm">Skip</a>
           </div>
-          <div *ngIf="!canSaveReview" style="font-size:11px; color:#999; margin-top:8px;">
+          <div *ngIf="!canSaveReview" style="font-size:11px; color:#999; margin-top:8px;" role="status">
             Fill in at least one field to save.
+          </div>
+        </div>
+      </div>
+
+      <!-- Save confirmation -->
+      <div *ngIf="saved" class="panel" style="margin-bottom:20px;" role="status" aria-live="polite">
+        <div class="panel-head">
+          <span class="panel-title">Session Saved</span>
+        </div>
+        <div class="panel-body">
+          <p style="margin:0 0 16px; font-size:13px; color:#555;">
+            Your brew session has been logged successfully.
+          </p>
+          <div style="display:flex; gap:12px;">
+            <a routerLink="/logs" class="btn btn-inv">View in Logs</a>
+            <a routerLink="/recipes" class="btn">Back to Recipes</a>
           </div>
         </div>
       </div>
@@ -223,8 +264,10 @@ export class RecipeBrewComponent implements OnInit, OnDestroy {
   get elapsedTotal(): number { return Math.floor(this.elapsedMs / 1000); }
 
   // Review form
-  review: { doseG?: number; yieldG?: number; extractionTimeS?: number; rating?: number; notes?: string } = {};
+  review: { doseG?: number; yieldG?: number; extractionTimeS?: number; rating?: number; extractionFeedback: number; notes?: string } = { extractionFeedback: 0 };
   saving = false;
+  saved = false;
+  saveError?: string;
 
   get stepRemaining(): number {
     const s = this.recipe?.steps[this.currentStepIndex];
@@ -242,10 +285,30 @@ export class RecipeBrewComponent implements OnInit, OnDestroy {
               this.review.rating || (this.review.notes && this.review.notes.trim()));
   }
 
+  get extractionLabel(): string {
+    const labels: Record<number, string> = {
+      '-3': 'Very Under-Extracted',
+      '-2': 'Under-Extracted',
+      '-1': 'Slightly Under',
+      '0': 'Balanced',
+      '1': 'Slightly Over',
+      '2': 'Over-Extracted',
+      '3': 'Very Over-Extracted',
+    };
+    return labels[this.review.extractionFeedback] ?? 'Balanced';
+  }
+
   ngOnInit() {
     const id = +this.route.snapshot.paramMap.get('id')!;
     this.recipeService.getById(id).subscribe(r => {
       this.recipe = r;
+      // Auto-prefill form fields from recipe
+      if (r.doseG != null) this.review.doseG = r.doseG;
+      if (r.waterG != null) this.review.yieldG = r.waterG;
+      if (r.steps?.length) {
+        const totalS = r.steps.reduce((sum, s) => sum + s.durationS, 0);
+        if (totalS > 0) this.review.extractionTimeS = totalS;
+      }
       if (r.grinderId) {
         this.grinderService.getById(r.grinderId).subscribe(g => this.grinder = g);
       }
@@ -316,21 +379,33 @@ export class RecipeBrewComponent implements OnInit, OnDestroy {
   saveReview() {
     if (!this.canSaveReview || !this.recipe || this.saving) return;
     this.saving = true;
+    this.saveError = undefined;
     const req: AddGrindLogRequest = {
-      coffeeId:        this.recipe.coffeeId,
-      grinderId:       this.recipe.grinderId,
-      brewMethod:      this.recipe.brewMethod,
-      nativeSetting:   this.recipe.nativeSetting ?? 0,
-      doseG:           this.review.doseG,
-      yieldG:          this.review.yieldG,
-      extractionTimeS: this.review.extractionTimeS,
-      rating:          this.review.rating,
-      notes:           this.review.notes?.trim() || undefined,
-      recipeId:        this.recipe.id,
+      coffeeId:           this.recipe.coffeeId,
+      grinderId:          this.recipe.grinderId,
+      brewMethod:         this.recipe.brewMethod,
+      nativeSetting:      this.recipe.nativeSetting ?? 0,
+      doseG:              this.review.doseG,
+      yieldG:             this.review.yieldG,
+      extractionTimeS:    this.review.extractionTimeS,
+      rating:             this.review.rating,
+      extractionFeedback: this.review.extractionFeedback !== 0 ? this.review.extractionFeedback : undefined,
+      notes:              this.review.notes?.trim() || undefined,
+      recipeId:           this.recipe.id,
     };
     this.logService.create(req).subscribe({
-      next:  () => this.router.navigate(['/logs']),
-      error: () => { this.saving = false; },
+      next: () => {
+        this.saving = false;
+        this.saved = true;
+      },
+      error: (err) => {
+        this.saving = false;
+        if (err.status === 409) {
+          this.saveError = err.error ?? 'A session for this recipe was already saved today.';
+        } else {
+          this.saveError = 'Failed to save session. Please try again.';
+        }
+      },
     });
   }
 

--- a/frontend/grind-atlas-ui/src/app/models/models.ts
+++ b/frontend/grind-atlas-ui/src/app/models/models.ts
@@ -171,8 +171,68 @@ export interface AddGrindLogRequest {
   yieldG?: number;
   extractionTimeS?: number;
   rating?: number;
+  extractionFeedback?: number;  // -3 (very under) to +3 (very over)
   notes?: string;
   recipeId?: number;
+}
+
+// Collection — My Shelf
+export interface UserCoffee {
+  id: number;
+  userId: string;
+  coffeeId: number;
+  addedAt: string;
+  coffee: Coffee;
+}
+
+// Collection — My Setup
+export interface UserGrinder {
+  id: number;
+  userId: string;
+  grinderId: number;
+  addedAt: string;
+  grinder: Grinder;
+}
+
+export interface UserBrewMethod {
+  id: number;
+  userId: string;
+  brewMethod: BrewMethod;
+  addedAt: string;
+}
+
+// Bag Tracking
+export interface CoffeeBag {
+  id: number;
+  userId: string;
+  coffeeId: number;
+  openedAt: string;
+  roastedOn?: string;
+  bagWeightG?: number;
+  notes?: string;
+  coffee: Coffee;
+}
+
+export interface OpenCoffeeBagRequest {
+  coffeeId: number;
+  roastedOn?: string;
+  bagWeightG?: number;
+  notes?: string;
+}
+
+export interface FreshnessInfo {
+  bagId: number;
+  coffeeId: number;
+  coffeeName: string;
+  openedAt: string;
+  roastedOn?: string;
+  daysSinceRoast?: number;
+  freshnessStatus: 'Too Fresh' | 'Peak' | 'Acceptable' | 'Past Peak' | 'Unknown';
+  peakStartDay?: number;
+  peakEndDay?: number;
+  usageRateGPerDay?: number;
+  estimatedDaysRemaining?: number;
+  isRunningLow: boolean;
 }
 
 // auth

--- a/frontend/grind-atlas-ui/src/app/services/services.ts
+++ b/frontend/grind-atlas-ui/src/app/services/services.ts
@@ -6,6 +6,7 @@ import {
   AddGrindLogRequest, BrewMethod, ProcessingMethod,
   AuthUser, LoginRequest, RegisterRequest,
   BrewRecipe, CreateBrewRecipeRequest,
+  UserCoffee, UserGrinder, UserBrewMethod, CoffeeBag, OpenCoffeeBagRequest, FreshnessInfo,
 } from '../models/models';
 
 const BASE = 'https://grindatlas.onrender.com/api';
@@ -140,6 +141,68 @@ export class RecipeService {
 
   delete(id: number): Observable<void> {
     return this.http.delete<void>(`${BASE}/recipes/${id}`);
+  }
+}
+
+// ── Collection Service ────────────────────────────────────────────────────────
+@Injectable({ providedIn: 'root' })
+export class CollectionService {
+  private http = inject(HttpClient);
+
+  // My Shelf — coffees
+  getShelf(): Observable<UserCoffee[]> {
+    return this.http.get<UserCoffee[]>(`${BASE}/collection/coffees`);
+  }
+
+  addToShelf(coffeeId: number): Observable<void> {
+    return this.http.post<void>(`${BASE}/collection/coffees/${coffeeId}`, {});
+  }
+
+  removeFromShelf(coffeeId: number): Observable<void> {
+    return this.http.delete<void>(`${BASE}/collection/coffees/${coffeeId}`);
+  }
+
+  // My Setup — grinders
+  getSetupGrinders(): Observable<UserGrinder[]> {
+    return this.http.get<UserGrinder[]>(`${BASE}/collection/grinders`);
+  }
+
+  addGrinderToSetup(grinderId: number): Observable<void> {
+    return this.http.post<void>(`${BASE}/collection/grinders/${grinderId}`, {});
+  }
+
+  removeGrinderFromSetup(grinderId: number): Observable<void> {
+    return this.http.delete<void>(`${BASE}/collection/grinders/${grinderId}`);
+  }
+
+  // My Setup — brew methods
+  getSetupBrewMethods(): Observable<UserBrewMethod[]> {
+    return this.http.get<UserBrewMethod[]>(`${BASE}/collection/brewmethods`);
+  }
+
+  addBrewMethodToSetup(method: BrewMethod): Observable<void> {
+    return this.http.post<void>(`${BASE}/collection/brewmethods/${method}`, {});
+  }
+
+  removeBrewMethodFromSetup(method: BrewMethod): Observable<void> {
+    return this.http.delete<void>(`${BASE}/collection/brewmethods/${method}`);
+  }
+
+  // Bag Tracking
+  getBags(): Observable<CoffeeBag[]> {
+    return this.http.get<CoffeeBag[]>(`${BASE}/collection/bags`);
+  }
+
+  openBag(req: OpenCoffeeBagRequest): Observable<CoffeeBag> {
+    return this.http.post<CoffeeBag>(`${BASE}/collection/bags`, req);
+  }
+
+  closeBag(bagId: number): Observable<void> {
+    return this.http.delete<void>(`${BASE}/collection/bags/${bagId}`);
+  }
+
+  getBagFreshness(bagId: number): Observable<FreshnessInfo> {
+    return this.http.get<FreshnessInfo>(`${BASE}/collection/bags/${bagId}/freshness`);
   }
 }
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,8 @@
   base    = "frontend/grind-atlas-ui"
   command = "npm run build"
   publish = "dist/grind-atlas-ui/browser"
+
+[[redirects]]
+  from   = "/*"
+  to     = "/index.html"
+  status = 200


### PR DESCRIPTION
## Summary

Closes #2, #3, #4, #8, #15, #16

---

## Issue #16 — Auth redirect for unauthenticated users

**Root cause:** Netlify had no SPA redirect rule. Direct URL access returned a server 404 before Angular could boot, so the auth guard never ran.

**Fix:** Added `[[redirects]]` catch-all in `netlify.toml` pointing all routes to `/index.html` with status 200. The existing `authGuard` already redirects unauthenticated users to `/` once Angular is running.

---

## Issue #15 — Save Session improvements

- **Auto-prefill:** Dose, Yield, and Extraction Time pre-populated from the recipe when the brew completes
- **Extraction slider:** -3 (Very Under-Extracted) to +3 (Very Over-Extracted) with labeled value; stored as `ExtractionFeedback` on `GrindLog` and surfaced to the Grind Advisor
- **Confirmation panel:** Replaces the immediate redirect — shows "Session Saved" with "View in Logs" and "Back to Recipes" actions
- **Duplicate prevention:** Backend returns 409 Conflict if the same recipe + user already has a log for today; frontend shows an inline error message instead of silently failing

---

## Issue #2 — My Shelf (owned coffees)

**Backend:**
- New `UserCoffee` model with unique index on `(UserId, CoffeeId)`
- `CollectionController` endpoints: `GET/POST/DELETE /api/collection/coffees/{coffeeId}` (idempotent add)

**Frontend:**
- Shelf badge + add/remove toggle button on every row in the Coffees catalog
- New `/collection/shelf` page listing owned coffees and surfacing bag tracking (Issue #8) per coffee
- "My Shelf" nav link in sidebar

---

## Issue #3 — My Setup (owned grinders & brew methods)

**Backend:**
- New `UserGrinder` and `UserBrewMethod` models with unique indexes
- Endpoints: `GET/POST/DELETE /api/collection/grinders/{id}` and `/api/collection/brewmethods/{method}`

**Frontend:**
- Setup badge + add/remove toggle on every grinder card in the Grinders catalog
- New `/collection/setup` page: grinder management + brew method toggles with optimistic UI (instant feedback, rollback on error)
- "My Setup" nav link in sidebar

---

## Issue #4 — Estimator: prioritize owned items in dropdowns

- Coffee dropdown: "My Shelf" `<optgroup>` surfaces first; "All Coffees" below
- Grinder dropdown: "My Setup" first; "All Grinders" below
- Brew method dropdown: My Setup methods listed directly; remaining methods in an "Other Methods" fallback group (full list shown if setup is empty)
- Collection data loaded in a single `forkJoin` on init; gracefully falls back to unfiltered lists on error

---

## Issue #8 — Coffee lifecycle: bag tracking

**Backend:**
- New `CoffeeBag` model: open date, roasted-on date, bag weight, notes
- `POST /api/collection/bags` — open a bag
- `DELETE /api/collection/bags/{id}` — close a bag
- `GET /api/collection/bags/{id}/freshness` — returns computed `FreshnessInfo`:
  - Freshness status: Too Fresh / Peak / Acceptable / Past Peak (windows vary by processing method — Washed 7–21d, Natural 14–35d, Honey 10–28d, Anaerobic 14–42d)
  - Usage rate (g/day) derived from grind logs since bag opened
  - Estimated days remaining based on bag weight and usage rate
  - Running low flag when ≤7 days remain

**Frontend:** Bag tracking surfaced on the My Shelf page per coffee.

---

## Tests

New xUnit project: `backend/GrindAtlas.API.Tests`

| Suite | Tests | Coverage |
|-------|-------|----------|
| `CollectionControllerTests` | 17 | Shelf add/remove/idempotency/user isolation, setup grinders, brew methods, bag open/close/freshness (Too Fresh, Peak, Past Peak, wrong user) |
| `GrindLogControllerTests` | 9 | Create log, duplicate detection (with/without recipeId), extraction feedback valid/invalid range, cross-user isolation, GetAll scoping |
| **Total** | **26** | **All passing** |

---

## Files changed

```
backend/GrindAtlas.API.Tests/                     ← new test project
  CollectionControllerTests.cs                    ← 17 tests
  GrindLogControllerTests.cs                      ← 9 tests
  GrindAtlas.API.Tests.csproj
backend/GrindAtlas.API/Models/Collection.cs       ← UserCoffee, UserGrinder, UserBrewMethod, CoffeeBag
backend/GrindAtlas.API/Models/GrindLog.cs         ← +ExtractionFeedback field
backend/GrindAtlas.API/Data/AppDbContext.cs       ← +4 DbSets, unique indexes
backend/GrindAtlas.API/DTOs/Dtos.cs               ← +ExtractionFeedback, OpenCoffeeBagRequest, FreshnessInfo
backend/GrindAtlas.API/Controllers/
  CollectionController.cs                         ← new (shelf, setup, bags)
  Controllers.cs                                  ← duplicate detection + ExtractionFeedback
frontend/.../models/models.ts                     ← +UserCoffee, UserGrinder, UserBrewMethod, CoffeeBag, FreshnessInfo
frontend/.../services/services.ts                 ← +CollectionService
frontend/.../components/collection/
  my-shelf.component.ts                           ← new
  my-setup.component.ts                           ← new
frontend/.../components/coffees/coffees.component.ts      ← +shelf toggles
frontend/.../components/grinders/grinders.component.ts   ← +setup toggles
frontend/.../components/grind-advisor/grind-advisor.component.ts  ← +grouped dropdowns
frontend/.../components/recipes/recipe-brew.component.ts ← +auto-prefill, slider, confirmation, 409 handling
frontend/.../app.routes.ts                        ← +/collection/shelf, /collection/setup
frontend/.../app.component.ts                     ← +My Shelf, My Setup nav links
netlify.toml                                      ← +SPA redirect rule
```