### PR TITLE
Fix add-coffee and add-grinder POST errors

### DIFF
--- a/backend/GrindAtlas.API/appsettings.json
+++ b/backend/GrindAtlas.API/appsettings.json
@@ -10,6 +10,7 @@
   "Admin": {
     "Email": "admin@grindatlas.com",
     "Password": "Admin123!"
+  },
   "EmailSettings": {
     "Host": "smtp.gmail.com",
     "Port": 587,


### PR DESCRIPTION
## Summary

- **`appsettings.json`** — Missing closing `}` on the `Admin` object caused `EmailSettings` to be nested inside it, producing a `JsonReaderException` at startup and preventing the backend from booting at all
- **`AuthController.cs`** — The async `GenerateToken` method's opening brace was never closed, so `ResendVerification`, `ConfirmEmail`, `ForgotPassword`, `ResetPassword`, and a second `GenerateToken` overload were all accidentally nested inside it. This was a compile error that prevented any new deployments from succeeding (Render was silently falling back to the last good build). Also fixed a duplicate `return` in `Register` so the welcome-email fire-and-forget actually runs.
- **`Controllers.cs`** — `POST /api/coffees` and `POST /api/grinders` were subject to the global `FallbackPolicy = RequireAuthenticatedUser` but had no `[Authorize]` or `[AllowAnonymous]`. Added `[AllowAnonymous]` so the create actions succeed and CORS headers are never stripped by a 401 challenge response.

## Test plan

- [ ] Render deploy succeeds (no startup crash)
- [ ] Add a coffee via the form — no "0 Unknown Error"
- [ ] Add a grinder via the form — no "0 Unknown Error"
- [ ] Login and register still work
- [ ] Password reset email flow still works

https://claude.ai/code/session_01SA6M8PTL9CZ7dtuPacRPjn